### PR TITLE
Modify Android CI for develop branch and JDK version

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,29 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "main", "develop" ] # develop 브랜치 푸시도 감지
+  pull_request:
+    branches: [ "main", "develop" ] # develop으로 향하는 PR도 감지
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: set up JDK 17 # 11 -> 17로 변경 (프로젝트 설정에 따라 선택)
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    - name: Build with Gradle
+      # 'build'는 테스트와 린트까지 포함하여 시간이 오래 걸릴 수 있습니다.
+      # 단순히 빌드 성공 여부만 보려면 'assembleDebug'를 쓰기도 합니다.
+      run: ./gradlew build


### PR DESCRIPTION
Updated CI configuration to detect pushes and PRs on 'develop' branch. Changed JDK version from 11 to 17.