### PR TITLE
Merge branch 'main' into develop

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,43 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+      
+    # 1. 유닛 테스트 실행 (테스트 실패 시 여기서 멈춤)
+    - name: Run Unit Tests
+      run: ./gradlew testDebugUnitTest
+
+    # 2. 린트 체크 (코드 스타일/잠재적 오류 검사)
+    # - name: Run Lint
+    #   run: ./gradlew lintDebug
+
+    # 3. 테스트와 린트를 통과하면 APK 빌드
+    - name: Build Debug APK
+      run: ./gradlew assembleDebug
+
+    # 4. APK 업로드
+    - name: Upload APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: debug-apk
+        path: app/build/outputs/apk/debug/*.apk


### PR DESCRIPTION
#5 
#6 

This pull request introduces a new GitHub Actions workflow for continuous integration (CI) on Android projects. The workflow automates testing, building, and artifact uploading for pushes and pull requests on the `main` and `develop` branches.

**CI/CD Workflow Automation:**

* Added `.github/workflows/android.yml` to define an Android CI pipeline that runs on every push or pull request to `main` or `develop`.
  * Checks out the code, sets up JDK 17, and grants execution permission to `gradlew`.
  * Runs unit tests and, if successful, builds the debug APK.
  * Uploads the generated debug APK as a workflow artifact.