### PR TITLE
Improve low-vision status visibility on the camera screen

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -2,6 +2,7 @@ package kr.co.gachon.pproject6.via
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.res.ColorStateList
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
@@ -66,6 +67,15 @@ class MainActivity : AppCompatActivity() {
         private const val MAX_CAMERA_COLD_START_RECOVERIES = 1
     }
 
+    private data class StatusVisualState(
+        val iconText: String,
+        val iconBackgroundColor: Int,
+        val iconTextColor: Int,
+        val tintColor: Int,
+        val borderResId: Int,
+        val badgeText: String?
+    )
+
     private lateinit var viewFinder: PreviewView
     private lateinit var overlay: OverlayView
     private lateinit var fpsText: TextView
@@ -85,6 +95,8 @@ class MainActivity : AppCompatActivity() {
     private lateinit var tuningDebugText: TextView
     private lateinit var statusTitleText: TextView
     private lateinit var statusDetailText: TextView
+    private lateinit var statusIconText: TextView
+    private lateinit var statusBadgeText: TextView
     private lateinit var confidenceSliderLabel: TextView
     private lateinit var trafficConfidenceLabel: TextView
     private lateinit var downTiltLabel: TextView
@@ -102,6 +114,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var topControlCard: View
     private lateinit var statusPanel: View
     private lateinit var statusBorder: View
+    private lateinit var statusTintOverlay: View
     private var lastLoggedDecisionSummary: String? = null
     private var lastLoggedMapSummary: String? = null
     private var suppressGpuToggleCallback = false
@@ -218,6 +231,7 @@ class MainActivity : AppCompatActivity() {
         viewFinder = findViewById(R.id.viewFinder)
         viewFinder.implementationMode = PreviewView.ImplementationMode.COMPATIBLE
         viewFinder.scaleType = PreviewView.ScaleType.FILL_CENTER
+        statusTintOverlay = findViewById(R.id.statusTintOverlay)
         overlay = findViewById(R.id.overlay)
         debugContainer = findViewById(R.id.debugContainer)
         debugToggleButton = findViewById(R.id.debugToggleButton)
@@ -241,6 +255,8 @@ class MainActivity : AppCompatActivity() {
         tuningDebugText = findViewById(R.id.tuningDebugText)
         statusTitleText = findViewById(R.id.statusTitleText)
         statusDetailText = findViewById(R.id.statusDetailText)
+        statusIconText = findViewById(R.id.statusIconText)
+        statusBadgeText = findViewById(R.id.statusBadgeText)
         confidenceSliderLabel = findViewById(R.id.confidenceSliderLabel)
         trafficConfidenceLabel = findViewById(R.id.trafficConfidenceLabel)
         downTiltLabel = findViewById(R.id.downTiltLabel)
@@ -777,7 +793,7 @@ class MainActivity : AppCompatActivity() {
                 updateDecisionDebugInfo(analysisResult, enableTrafficLogic)
                 updateGpsDebugMapButtonState()
                 updateUserStatus(analysisResult, enableTrafficLogic)
-                updateStatusBorder(analysisResult.userGuidanceState, enableTrafficLogic)
+                updateStatusVisuals(analysisResult, enableTrafficLogic)
                 logDecisionIfChanged(analysisResult, enableTrafficLogic)
                 logMapIfChanged(analysisResult.crossingSupportSnapshot)
 
@@ -1111,6 +1127,79 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun updateStatusVisuals(
+        analysisResult: SignalAnalysisResult,
+        enableTrafficLogic: Boolean
+    ) {
+        if (!enableTrafficLogic) {
+            statusBorder.setBackgroundResource(R.drawable.border_transparent)
+            statusTintOverlay.setBackgroundColor(Color.TRANSPARENT)
+            statusTintOverlay.alpha = 0f
+            statusIconText.text = "?"
+            statusIconText.setTextColor(ContextCompat.getColor(this, R.color.via_on_surface))
+            statusIconText.backgroundTintList =
+                ColorStateList.valueOf(ContextCompat.getColor(this, R.color.via_status_wait))
+            statusBadgeText.visibility = View.GONE
+            return
+        }
+
+        val visualState = deriveStatusVisualState(analysisResult)
+        statusBorder.setBackgroundResource(visualState.borderResId)
+        statusTintOverlay.setBackgroundColor(visualState.tintColor)
+        statusTintOverlay.alpha = if (visualState.tintColor == Color.TRANSPARENT) 0f else 1f
+        statusIconText.text = visualState.iconText
+        statusIconText.setTextColor(visualState.iconTextColor)
+        statusIconText.backgroundTintList = ColorStateList.valueOf(visualState.iconBackgroundColor)
+        statusBadgeText.visibility = if (visualState.badgeText != null) View.VISIBLE else View.GONE
+        statusBadgeText.text = visualState.badgeText ?: ""
+    }
+
+    private fun deriveStatusVisualState(
+        analysisResult: SignalAnalysisResult
+    ): StatusVisualState {
+        return when {
+            analysisResult.userGuidanceState == UserGuidanceState.STOP ->
+                StatusVisualState(
+                    iconText = "■",
+                    iconBackgroundColor = ContextCompat.getColor(this, R.color.via_status_stop),
+                    iconTextColor = ContextCompat.getColor(this, R.color.via_on_primary),
+                    tintColor = ContextCompat.getColor(this, R.color.via_status_stop_tint),
+                    borderResId = R.drawable.border_red,
+                    badgeText = null
+                )
+
+            analysisResult.userGuidanceState == UserGuidanceState.GO && analysisResult.occupancyCaution ->
+                StatusVisualState(
+                    iconText = "▶",
+                    iconBackgroundColor = ContextCompat.getColor(this, R.color.via_status_go),
+                    iconTextColor = ContextCompat.getColor(this, R.color.via_on_primary),
+                    tintColor = Color.TRANSPARENT,
+                    borderResId = R.drawable.border_green,
+                    badgeText = "차량 주의"
+                )
+
+            analysisResult.userGuidanceState == UserGuidanceState.GO ->
+                StatusVisualState(
+                    iconText = "▶",
+                    iconBackgroundColor = ContextCompat.getColor(this, R.color.via_status_go),
+                    iconTextColor = ContextCompat.getColor(this, R.color.via_on_primary),
+                    tintColor = ContextCompat.getColor(this, R.color.via_status_go_tint),
+                    borderResId = R.drawable.border_green,
+                    badgeText = null
+                )
+
+            else ->
+                StatusVisualState(
+                    iconText = "…",
+                    iconBackgroundColor = ContextCompat.getColor(this, R.color.via_status_wait),
+                    iconTextColor = ContextCompat.getColor(this, R.color.via_on_primary),
+                    tintColor = Color.TRANSPARENT,
+                    borderResId = R.drawable.border_transparent,
+                    badgeText = null
+                )
+        }
+    }
+
     private fun logDecisionIfChanged(
         analysisResult: SignalAnalysisResult,
         enableTrafficLogic: Boolean
@@ -1142,22 +1231,6 @@ class MainActivity : AppCompatActivity() {
         if (summary != lastLoggedMapSummary) {
             lastLoggedMapSummary = summary
             Log.i("VIA_MAP", summary)
-        }
-    }
-
-    private fun updateStatusBorder(
-        guidanceState: UserGuidanceState,
-        enableTrafficLogic: Boolean
-    ) {
-        if (!enableTrafficLogic) {
-            statusBorder.setBackgroundResource(R.drawable.border_transparent)
-            return
-        }
-
-        when (guidanceState) {
-            UserGuidanceState.STOP -> statusBorder.setBackgroundResource(R.drawable.border_red)
-            UserGuidanceState.GO -> statusBorder.setBackgroundResource(R.drawable.border_green)
-            UserGuidanceState.WAIT -> statusBorder.setBackgroundResource(R.drawable.border_transparent)
         }
     }
 

--- a/app/src/main/res/drawable/status_badge_background.xml
+++ b/app/src/main/res/drawable/status_badge_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="999dp" />
+    <solid android:color="@color/via_status_caution" />
+</shape>

--- a/app/src/main/res/drawable/status_icon_background.xml
+++ b/app/src/main/res/drawable/status_icon_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@android:color/white" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,6 +15,14 @@
         android:contentDescription="실시간 카메라 미리보기" />
 
     <View
+        android:id="@+id/statusTintOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:alpha="0"
+        android:background="@android:color/transparent"
+        android:translationZ="2dp" />
+
+    <View
         android:id="@+id/statusBorder"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -104,9 +112,36 @@
             android:paddingBottom="20dp">
 
             <TextView
+                android:id="@+id/statusIconText"
+                android:layout_width="112dp"
+                android:layout_height="112dp"
+                android:background="@drawable/status_icon_background"
+                android:gravity="center"
+                android:text="?"
+                android:textColor="@color/via_on_surface"
+                android:textSize="54sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/statusBadgeText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:background="@drawable/status_badge_background"
+                android:gravity="center"
+                android:paddingHorizontal="14dp"
+                android:paddingVertical="8dp"
+                android:text="차량 주의"
+                android:textColor="@color/via_status_badge_on"
+                android:textSize="15sp"
+                android:textStyle="bold"
+                android:visibility="gone" />
+
+            <TextView
                 android:id="@+id/statusTitleText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
                 android:gravity="center"
                 android:text="신호 상태 확인 중"
                 android:textColor="@color/via_on_surface"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -19,7 +19,7 @@
     <color name="via_status_stop">#FFFF6B6B</color>
     <color name="via_status_wait">#FF7F8A99</color>
     <color name="via_status_caution">#FFFFC857</color>
-    <color name="via_status_go_tint">#2641C75E</color>
-    <color name="via_status_stop_tint">#26FF6B6B</color>
+    <color name="via_status_go_tint">#4D41C75E</color>
+    <color name="via_status_stop_tint">#52FF6B6B</color>
     <color name="via_status_badge_on">#FF1B1F24</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,4 +15,11 @@
     <color name="via_on_primary">#FFFFFFFF</color>
     <color name="via_secondary">#FF9BDB4D</color>
     <color name="via_error">#FFFF6B6B</color>
+    <color name="via_status_go">#FF51CF66</color>
+    <color name="via_status_stop">#FFFF6B6B</color>
+    <color name="via_status_wait">#FF7F8A99</color>
+    <color name="via_status_caution">#FFFFC857</color>
+    <color name="via_status_go_tint">#2641C75E</color>
+    <color name="via_status_stop_tint">#26FF6B6B</color>
+    <color name="via_status_badge_on">#FF1B1F24</color>
 </resources>


### PR DESCRIPTION
## Summary
- strengthen the camera-screen status UI for low-vision users with fullscreen GO/STOP tinting and large central status badges
- keep WAIT and GO+CAUTION visually calmer so the screen does not become noisy during normal guidance updates

## What changed
- add a full-screen tint overlay layer behind the debug/overlay content
- show stronger green and red tint for GO and STOP states while keeping the camera feed visible underneath
- add a large central badge/icon treatment inside the bottom status card
- keep GO+CAUTION on the green visual language but surface a dedicated caution badge instead of tinting the full screen yellow
- keep WAIT neutral so only the strongest stop/go states dominate the screen
- tune tint opacity upward after the first pass so the effect reads more clearly on live camera footage

## Testing
- `./gradlew.bat testDebugUnitTest`
- `./gradlew.bat lintDebug`
- `./gradlew.bat assembleDebug`
- installed updated debug APK on a connected Android device with `adb install --no-streaming -r`

## Reviewer focus
- whether GO/STOP tint strength is readable without obscuring the camera view too much
- whether the large badge/icon treatment improves fast recognition for low-vision use
- whether GO+CAUTION and WAIT remain visually distinct without overloading the screen