### PR TITLE
Fix traffic-light detection regression and overlay alignment

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -328,8 +328,8 @@ class MainActivity : AppCompatActivity() {
 
         confidenceSlider.value = 0.5f
         trafficConfidenceSlider.value = 0.15f
-        downTiltSlider.value = 20f
-        downTiltSlider.isEnabled = false
+        downTiltSlider.value = crossingSupportManager.currentLookingDownThresholdDegrees()
+        downTiltSlider.isEnabled = true
         updateDownTiltLabel()
 
         gpuSwitch.setOnCheckedChangeListener { _, isChecked ->
@@ -505,11 +505,12 @@ class MainActivity : AppCompatActivity() {
 
     private fun updateTuningDebugText() {
         tuningDebugText.text =
-            "Tuning: ${GuidanceTuningDefaults.toDebugSummary()}, tilt raw down=-160..-90, up=90..120"
+            "Tuning: ${GuidanceTuningDefaults.toDebugSummary()}, tilt raw down=-160..-${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingDownThresholdDegrees())}, up=90..${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingUpThresholdDegrees())}"
     }
 
     private fun updateDownTiltLabel() {
-        downTiltLabel.text = "Tilt Raw Range: down -160..-90 / up 90..120"
+        downTiltLabel.text =
+            "Tilt Raw Range: down -160..-${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingDownThresholdDegrees())} / up 90..${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingUpThresholdDegrees())}"
     }
 
     private fun updateDebugInfo(

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -166,7 +166,7 @@ class MainActivity : AppCompatActivity() {
     private val processingScheduled = AtomicBoolean(false)
     private val imageProxyTransformFactory =
         ImageProxyTransformFactory().apply {
-            setUsingCropRect(true)
+            setUsingCropRect(false)
             setUsingRotationDegrees(true)
         }
 
@@ -635,6 +635,9 @@ class MainActivity : AppCompatActivity() {
                 runOnUiThread {
                     zoomSwitch.isEnabled = true
                     zoomSwitch.text = "Use 2x Zoom"
+                    suppressZoomToggleCallback = true
+                    zoomSwitch.isChecked = true
+                    suppressZoomToggleCallback = false
                     applySelectedZoom()
                 }
             } else {
@@ -731,7 +734,6 @@ class MainActivity : AppCompatActivity() {
         try {
             val copyStartNs = SystemClock.elapsedRealtimeNanos()
             val analysisOutputTransform = imageProxyTransformFactory.getOutputTransform(imageProxy)
-            val cropRect = imageProxy.cropRect
             val bitmap = imageProxy.toBitmap()
             val rotationDegrees = imageProxy.imageInfo.rotationDegrees
             imageProxy.close()
@@ -739,13 +741,12 @@ class MainActivity : AppCompatActivity() {
             stageDurationsMs["copy"] = elapsedMillis(copyStartNs)
 
             val rotateStartNs = SystemClock.elapsedRealtimeNanos()
-            val croppedBitmap = ImageUtils.cropBitmap(bitmap, cropRect)
             val rotatedBitmap = ImageUtils.rotateBitmap(
-                bitmap = croppedBitmap,
+                bitmap = bitmap,
                 degrees = rotationDegrees.toFloat(),
                 reusableBitmap = reusableRotatedBitmap
             )
-            if (rotatedBitmap !== croppedBitmap) {
+            if (rotatedBitmap !== bitmap) {
                 reusableRotatedBitmap = rotatedBitmap
             }
             stageDurationsMs["rotate"] = elapsedMillis(rotateStartNs)

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -21,9 +21,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.ImageProxy
 import androidx.camera.view.PreviewView
-import androidx.camera.view.transform.CoordinateTransform
-import androidx.camera.view.transform.ImageProxyTransformFactory
-import androidx.camera.view.transform.OutputTransform
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.slider.Slider
 import java.util.concurrent.ExecutorService
@@ -164,11 +161,6 @@ class MainActivity : AppCompatActivity() {
     private val cameraRateTracker = RateTracker(label = "Camera FPS")
     private val pendingFrame = AtomicReference<ImageProxy?>(null)
     private val processingScheduled = AtomicBoolean(false)
-    private val imageProxyTransformFactory =
-        ImageProxyTransformFactory().apply {
-            setUsingCropRect(false)
-            setUsingRotationDegrees(true)
-        }
 
     private val signalAnalyzer = SignalAnalyzer()
     private val guidanceStateStabilizer =
@@ -733,7 +725,6 @@ class MainActivity : AppCompatActivity() {
 
         try {
             val copyStartNs = SystemClock.elapsedRealtimeNanos()
-            val analysisOutputTransform = imageProxyTransformFactory.getOutputTransform(imageProxy)
             val bitmap = imageProxy.toBitmap()
             val rotationDegrees = imageProxy.imageInfo.rotationDegrees
             imageProxy.close()
@@ -787,8 +778,7 @@ class MainActivity : AppCompatActivity() {
                 renderOverlay(
                     bitmap = rotatedBitmap,
                     analysisResult = analysisResult,
-                    showRawBoxes = rawDetectionSwitch.isChecked,
-                    analysisOutputTransform = analysisOutputTransform
+                    showRawBoxes = rawDetectionSwitch.isChecked
                 )
                 updateTargetInfo(analysisResult, enableTrafficLogic)
                 updateDecisionDebugInfo(analysisResult, enableTrafficLogic)
@@ -830,62 +820,13 @@ class MainActivity : AppCompatActivity() {
     private fun renderOverlay(
         bitmap: Bitmap,
         analysisResult: SignalAnalysisResult,
-        showRawBoxes: Boolean,
-        analysisOutputTransform: OutputTransform?
+        showRawBoxes: Boolean
     ) {
+        overlay.setInputImageSize(bitmap.width, bitmap.height)
         if (showRawBoxes && showBBoxOverlay) {
-            val mappedBoxes =
-                mapBoxesToPreviewView(
-                    boxes = analysisResult.boxesToShow,
-                    sourceWidth = bitmap.width.toFloat(),
-                    sourceHeight = bitmap.height.toFloat(),
-                    analysisOutputTransform = analysisOutputTransform
-                )
-            if (mappedBoxes != null) {
-                overlay.setResults(mappedBoxes, inViewCoordinates = true)
-            } else {
-                overlay.setInputImageSize(bitmap.width, bitmap.height)
-                overlay.setResults(analysisResult.boxesToShow)
-            }
+            overlay.setResults(analysisResult.boxesToShow)
         } else {
-            overlay.setResults(emptyList(), inViewCoordinates = true)
-        }
-    }
-
-    private fun mapBoxesToPreviewView(
-        boxes: List<OverlayView.BoundingBox>,
-        sourceWidth: Float,
-        sourceHeight: Float,
-        analysisOutputTransform: OutputTransform?
-    ): List<OverlayView.BoundingBox>? {
-        if (analysisOutputTransform == null) {
-            return null
-        }
-
-        val previewOutputTransform = viewFinder.outputTransform ?: return null
-
-        return try {
-            val coordinateTransform =
-                CoordinateTransform(analysisOutputTransform, previewOutputTransform)
-            boxes.map { box ->
-                val mappedRect = RectF(
-                    box.box.left * sourceWidth,
-                    box.box.top * sourceHeight,
-                    box.box.right * sourceWidth,
-                    box.box.bottom * sourceHeight
-                )
-                coordinateTransform.mapRect(mappedRect)
-                OverlayView.BoundingBox(
-                    box = mappedRect,
-                    clsName = box.clsName,
-                    score = box.score,
-                    debugRatio = box.debugRatio,
-                    isTarget = box.isTarget
-                )
-            }
-        } catch (e: IllegalArgumentException) {
-            Log.w("MainActivity", "Preview transform unavailable for overlay mapping", e)
-            null
+            overlay.setResults(emptyList())
         }
     }
 

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -21,6 +21,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.ImageProxy
 import androidx.camera.view.PreviewView
+import androidx.camera.view.transform.CoordinateTransform
+import androidx.camera.view.transform.ImageProxyTransformFactory
+import androidx.camera.view.transform.OutputTransform
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.slider.Slider
 import java.util.concurrent.ExecutorService
@@ -161,6 +164,11 @@ class MainActivity : AppCompatActivity() {
     private val cameraRateTracker = RateTracker(label = "Camera FPS")
     private val pendingFrame = AtomicReference<ImageProxy?>(null)
     private val processingScheduled = AtomicBoolean(false)
+    private val imageProxyTransformFactory =
+        ImageProxyTransformFactory().apply {
+            setUsingCropRect(false)
+            setUsingRotationDegrees(true)
+        }
 
     private val signalAnalyzer = SignalAnalyzer()
     private val guidanceStateStabilizer =
@@ -725,6 +733,7 @@ class MainActivity : AppCompatActivity() {
 
         try {
             val copyStartNs = SystemClock.elapsedRealtimeNanos()
+            val analysisOutputTransform = imageProxyTransformFactory.getOutputTransform(imageProxy)
             val bitmap = imageProxy.toBitmap()
             val rotationDegrees = imageProxy.imageInfo.rotationDegrees
             imageProxy.close()
@@ -778,7 +787,8 @@ class MainActivity : AppCompatActivity() {
                 renderOverlay(
                     bitmap = rotatedBitmap,
                     analysisResult = analysisResult,
-                    showRawBoxes = rawDetectionSwitch.isChecked
+                    showRawBoxes = rawDetectionSwitch.isChecked,
+                    analysisOutputTransform = analysisOutputTransform
                 )
                 updateTargetInfo(analysisResult, enableTrafficLogic)
                 updateDecisionDebugInfo(analysisResult, enableTrafficLogic)
@@ -820,13 +830,62 @@ class MainActivity : AppCompatActivity() {
     private fun renderOverlay(
         bitmap: Bitmap,
         analysisResult: SignalAnalysisResult,
-        showRawBoxes: Boolean
+        showRawBoxes: Boolean,
+        analysisOutputTransform: OutputTransform?
     ) {
-        overlay.setInputImageSize(bitmap.width, bitmap.height)
         if (showRawBoxes && showBBoxOverlay) {
-            overlay.setResults(analysisResult.boxesToShow)
+            val mappedBoxes =
+                mapBoxesToPreviewView(
+                    boxes = analysisResult.boxesToShow,
+                    sourceWidth = bitmap.width.toFloat(),
+                    sourceHeight = bitmap.height.toFloat(),
+                    analysisOutputTransform = analysisOutputTransform
+                )
+            if (mappedBoxes != null) {
+                overlay.setResults(mappedBoxes, inViewCoordinates = true)
+            } else {
+                overlay.setInputImageSize(bitmap.width, bitmap.height)
+                overlay.setResults(analysisResult.boxesToShow)
+            }
         } else {
             overlay.setResults(emptyList())
+        }
+    }
+
+    private fun mapBoxesToPreviewView(
+        boxes: List<OverlayView.BoundingBox>,
+        sourceWidth: Float,
+        sourceHeight: Float,
+        analysisOutputTransform: OutputTransform?
+    ): List<OverlayView.BoundingBox>? {
+        if (analysisOutputTransform == null) {
+            return null
+        }
+
+        val previewOutputTransform = viewFinder.outputTransform ?: return null
+
+        return try {
+            val coordinateTransform =
+                CoordinateTransform(analysisOutputTransform, previewOutputTransform)
+            boxes.map { box ->
+                val mappedRect = RectF(
+                    box.box.left * sourceWidth,
+                    box.box.top * sourceHeight,
+                    box.box.right * sourceWidth,
+                    box.box.bottom * sourceHeight
+                )
+                coordinateTransform.mapRect(mappedRect)
+                OverlayView.BoundingBox(
+                    box = mappedRect,
+                    clsName = box.clsName,
+                    score = box.score,
+                    debugRatio = box.debugRatio,
+                    isTarget = box.isTarget
+                )
+            }
+        } catch (e: IllegalArgumentException) {
+            Log.w("MainActivity", "Preview transform unavailable for overlay mapping", e)
+            null
         }
     }
 

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -100,9 +100,11 @@ class MainActivity : AppCompatActivity() {
     private lateinit var confidenceSliderLabel: TextView
     private lateinit var trafficConfidenceLabel: TextView
     private lateinit var downTiltLabel: TextView
+    private lateinit var upTiltLabel: TextView
     private lateinit var confidenceSlider: Slider
     private lateinit var trafficConfidenceSlider: Slider
     private lateinit var downTiltSlider: Slider
+    private lateinit var upTiltSlider: Slider
     private lateinit var gpuSwitch: com.google.android.material.switchmaterial.SwitchMaterial
     private lateinit var zoomSwitch: androidx.appcompat.widget.SwitchCompat
     private lateinit var rawDetectionSwitch: androidx.appcompat.widget.SwitchCompat
@@ -260,9 +262,11 @@ class MainActivity : AppCompatActivity() {
         confidenceSliderLabel = findViewById(R.id.confidenceSliderLabel)
         trafficConfidenceLabel = findViewById(R.id.trafficConfidenceLabel)
         downTiltLabel = findViewById(R.id.downTiltLabel)
+        upTiltLabel = findViewById(R.id.upTiltLabel)
         confidenceSlider = findViewById(R.id.confidenceSlider)
         trafficConfidenceSlider = findViewById(R.id.trafficConfidenceSlider)
         downTiltSlider = findViewById(R.id.downTiltSlider)
+        upTiltSlider = findViewById(R.id.upTiltSlider)
         gpuSwitch = findViewById(R.id.gpuSwitch)
         zoomSwitch = findViewById(R.id.swZoom2x)
         rawDetectionSwitch = findViewById(R.id.swRawDetection)
@@ -325,12 +329,20 @@ class MainActivity : AppCompatActivity() {
             updateDownTiltLabel()
             updateTuningDebugText()
         }
+        upTiltSlider.addOnChangeListener { _, value, _ ->
+            crossingSupportManager.updateLookingUpThresholdDegrees(value)
+            updateUpTiltLabel()
+            updateTuningDebugText()
+        }
 
         confidenceSlider.value = 0.5f
         trafficConfidenceSlider.value = 0.15f
         downTiltSlider.value = crossingSupportManager.currentLookingDownThresholdDegrees()
+        upTiltSlider.value = crossingSupportManager.currentLookingUpThresholdDegrees()
         downTiltSlider.isEnabled = true
+        upTiltSlider.isEnabled = true
         updateDownTiltLabel()
+        updateUpTiltLabel()
 
         gpuSwitch.setOnCheckedChangeListener { _, isChecked ->
             if (suppressGpuToggleCallback) {
@@ -510,7 +522,12 @@ class MainActivity : AppCompatActivity() {
 
     private fun updateDownTiltLabel() {
         downTiltLabel.text =
-            "Tilt Raw Range: down -160..-${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingDownThresholdDegrees())} / up 90..${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingUpThresholdDegrees())}"
+            "Down Tilt Range: -160..-${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingDownThresholdDegrees())}"
+    }
+
+    private fun updateUpTiltLabel() {
+        upTiltLabel.text =
+            "Up Tilt Range: 90..${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingUpThresholdDegrees())}"
     }
 
     private fun updateDebugInfo(
@@ -896,11 +913,16 @@ class MainActivity : AppCompatActivity() {
     ) {
         targetInfoText.text = if (enableTrafficLogic) {
             buildString {
-                appendLine("Target: ${analysisResult.targetClassName}")
-                appendLine("Score : ${String.format(Locale.US, "%.2f", analysisResult.targetScore)}")
-                if (analysisResult.targetBox != null && analysisResult.targetBox.debugRatio >= 0f) {
-                    appendLine("Ratio : ${String.format(Locale.US, "%.2f", analysisResult.targetBox.debugRatio)}")
-                }
+                appendLine("Target : ${analysisResult.targetClassName}")
+                appendLine("Score  : ${String.format(Locale.US, "%.2f", analysisResult.targetScore)}")
+                appendLine(
+                    "Ratio  : ${
+                        analysisResult.targetBox
+                            ?.takeIf { it.debugRatio >= 0f }
+                            ?.let { String.format(Locale.US, "%.2f", it.debugRatio) }
+                            ?: "--"
+                    }"
+                )
                 append(
                     if (analysisResult.occupancyCaution) {
                         "Caution: ${analysisResult.occupancyCautionLabels.joinToString(", ")}"
@@ -910,7 +932,7 @@ class MainActivity : AppCompatActivity() {
                 )
             }
         } else {
-            "Logic Disabled"
+            "Target : None\nScore  : 0.00\nRatio  : --\nCaution: none"
         }
     }
 
@@ -946,7 +968,7 @@ class MainActivity : AppCompatActivity() {
                 )
             }
         } else {
-            "Decision: DISABLED"
+            "Decision: DISABLED\nPhase   : --\nReason  : --\nTraffic : --\nMotion  : --\nTilt    : --\nWindow  : --\nGPSFix  : --\nContext : --\nMap     : --"
         }
     }
 

--- a/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraManager.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraManager.kt
@@ -8,6 +8,7 @@ import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview
+import androidx.camera.core.UseCaseGroup
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
@@ -26,6 +27,12 @@ class CameraManager(
     private var cameraProvider: ProcessCameraProvider? = null
 
     fun startCamera(onZoomStateReady: ((maxZoom: Float) -> Unit)? = null) {
+        val viewPort = viewFinder.viewPort
+        if (viewPort == null) {
+            viewFinder.post { startCamera(onZoomStateReady) }
+            return
+        }
+
         val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
 
         cameraProviderFuture.addListener({
@@ -53,11 +60,15 @@ class CameraManager(
 
             try {
                 cameraProvider.unbindAll()
+                val useCaseGroup = UseCaseGroup.Builder()
+                    .addUseCase(preview)
+                    .addUseCase(imageAnalyzer)
+                    .setViewPort(viewPort)
+                    .build()
                 camera = cameraProvider.bindToLifecycle(
                     lifecycleOwner,
                     cameraSelector,
-                    preview,
-                    imageAnalyzer
+                    useCaseGroup
                 )
 
                 // Check Zoom capabilities if callback provided

--- a/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraManager.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraManager.kt
@@ -8,7 +8,6 @@ import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.ImageProxy
 import androidx.camera.core.Preview
-import androidx.camera.core.UseCaseGroup
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
@@ -27,12 +26,6 @@ class CameraManager(
     private var cameraProvider: ProcessCameraProvider? = null
 
     fun startCamera(onZoomStateReady: ((maxZoom: Float) -> Unit)? = null) {
-        val viewPort = viewFinder.viewPort
-        if (viewPort == null) {
-            viewFinder.post { startCamera(onZoomStateReady) }
-            return
-        }
-
         val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
 
         cameraProviderFuture.addListener({
@@ -60,15 +53,11 @@ class CameraManager(
 
             try {
                 cameraProvider.unbindAll()
-                val useCaseGroup = UseCaseGroup.Builder()
-                    .addUseCase(preview)
-                    .addUseCase(imageAnalyzer)
-                    .setViewPort(viewPort)
-                    .build()
                 camera = cameraProvider.bindToLifecycle(
                     lifecycleOwner,
                     cameraSelector,
-                    useCaseGroup
+                    preview,
+                    imageAnalyzer
                 )
 
                 // Check Zoom capabilities if callback provided

--- a/app/src/main/java/kr/co/gachon/pproject6/via/context/CrossingSupportManager.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/context/CrossingSupportManager.kt
@@ -46,6 +46,8 @@ class CrossingSupportManager(
     private var gpsRegistered = false
     private var networkRegistered = false
     private var lastHeadingDegrees: Float? = null
+    private var lookingDownRawTiltRangeStartDegrees = config.lookingDownRawTiltRangeStartDegrees
+    private var lookingDownRawTiltRangeEndDegrees = config.lookingDownRawTiltRangeEndDegrees
     private val mapProximityManager = MapProximityManager(appContext, timeProvider)
 
     private val locationListener = LocationListener { location ->
@@ -76,9 +78,12 @@ class CrossingSupportManager(
         unregisterLocationUpdates()
     }
 
-    fun updateLookingDownThresholdDegrees(value: Float) = Unit
+    fun updateLookingDownThresholdDegrees(value: Float) {
+        val clampedThresholdDegrees = value.coerceIn(70f, 140f)
+        lookingDownRawTiltRangeEndDegrees = -clampedThresholdDegrees
+    }
 
-    fun currentLookingDownThresholdDegrees(): Float = config.lookingDownRawTiltRangeStartDegrees
+    fun currentLookingDownThresholdDegrees(): Float = kotlin.math.abs(lookingDownRawTiltRangeEndDegrees)
 
     fun currentLookingUpThresholdDegrees(): Float = config.lookingUpRawTiltRangeEndDegrees
 
@@ -230,7 +235,7 @@ class CrossingSupportManager(
                 val tiltDegrees = abs(signedTiltDegrees)
                 currentSignedTiltDegrees = signedTiltDegrees
                 currentTiltDegrees = tiltDegrees
-                if (signedTiltDegrees in config.lookingDownRawTiltRangeStartDegrees..config.lookingDownRawTiltRangeEndDegrees) {
+                if (signedTiltDegrees in lookingDownRawTiltRangeStartDegrees..lookingDownRawTiltRangeEndDegrees) {
                     if (lookingDownStartedAt == Long.MIN_VALUE) {
                         lookingDownStartedAt = timeProvider()
                     }

--- a/app/src/main/java/kr/co/gachon/pproject6/via/context/CrossingSupportManager.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/context/CrossingSupportManager.kt
@@ -48,6 +48,8 @@ class CrossingSupportManager(
     private var lastHeadingDegrees: Float? = null
     private var lookingDownRawTiltRangeStartDegrees = config.lookingDownRawTiltRangeStartDegrees
     private var lookingDownRawTiltRangeEndDegrees = config.lookingDownRawTiltRangeEndDegrees
+    private var lookingUpRawTiltRangeStartDegrees = config.lookingUpRawTiltRangeStartDegrees
+    private var lookingUpRawTiltRangeEndDegrees = config.lookingUpRawTiltRangeEndDegrees
     private val mapProximityManager = MapProximityManager(appContext, timeProvider)
 
     private val locationListener = LocationListener { location ->
@@ -85,7 +87,12 @@ class CrossingSupportManager(
 
     fun currentLookingDownThresholdDegrees(): Float = kotlin.math.abs(lookingDownRawTiltRangeEndDegrees)
 
-    fun currentLookingUpThresholdDegrees(): Float = config.lookingUpRawTiltRangeEndDegrees
+    fun updateLookingUpThresholdDegrees(value: Float) {
+        val clampedThresholdDegrees = value.coerceIn(90f, 170f)
+        lookingUpRawTiltRangeEndDegrees = clampedThresholdDegrees
+    }
+
+    fun currentLookingUpThresholdDegrees(): Float = lookingUpRawTiltRangeEndDegrees
 
     fun setCrossingWindowActive(isActive: Boolean) {
         val now = timeProvider()
@@ -243,7 +250,7 @@ class CrossingSupportManager(
                     lookingDownStartedAt = Long.MIN_VALUE
                 }
 
-                if (signedTiltDegrees in config.lookingUpRawTiltRangeStartDegrees..config.lookingUpRawTiltRangeEndDegrees) {
+                if (signedTiltDegrees in lookingUpRawTiltRangeStartDegrees..lookingUpRawTiltRangeEndDegrees) {
                     if (lookingUpStartedAt == Long.MIN_VALUE) {
                         lookingUpStartedAt = timeProvider()
                     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -294,7 +294,8 @@
                     android:layout_marginTop="12dp"
                     android:fontFamily="monospace"
                     android:lineSpacingExtra="4dp"
-                    android:text="Target: None"
+                    android:minLines="4"
+                    android:text="Target : None&#10;Score  : 0.00&#10;Ratio  : --&#10;Caution: none"
                     android:textColor="@color/via_accent"
                     android:textSize="15sp"
                     android:textStyle="bold" />
@@ -306,7 +307,8 @@
                     android:layout_marginTop="8dp"
                     android:fontFamily="monospace"
                     android:lineSpacingExtra="4dp"
-                    android:text="Decision: WAIT"
+                    android:minLines="8"
+                    android:text="Decision: WAIT&#10;Phase   : --&#10;Reason  : --&#10;Traffic : --&#10;Motion  : --&#10;Tilt    : --&#10;Window  : --&#10;GPSFix  : --&#10;Context : --&#10;Map     : --"
                     android:textColor="@color/via_on_surface"
                     android:textSize="14sp" />
 
@@ -435,7 +437,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
-                    android:text="Tilt Raw Range: down -160..-90 / up 90..120"
+                    android:text="Down Tilt Range: -160..-90"
                     android:textColor="@color/via_on_surface"
                     android:textSize="16sp"
                     android:textStyle="bold" />
@@ -447,6 +449,25 @@
                     android:value="90"
                     android:valueFrom="70.0"
                     android:valueTo="140.0"
+                    android:stepSize="1.0" />
+
+                <TextView
+                    android:id="@+id/upTiltLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="Up Tilt Range: 90..120"
+                    android:textColor="@color/via_on_surface"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.slider.Slider
+                    android:id="@+id/upTiltSlider"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:value="120"
+                    android:valueFrom="90.0"
+                    android:valueTo="170.0"
                     android:stepSize="1.0" />
             </LinearLayout>
         </ScrollView>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -435,7 +435,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
-                    android:text="Down Tilt: 45°"
+                    android:text="Tilt Raw Range: down -160..-90 / up 90..120"
                     android:textColor="@color/via_on_surface"
                     android:textSize="16sp"
                     android:textStyle="bold" />
@@ -444,9 +444,9 @@
                     android:id="@+id/downTiltSlider"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:value="45"
-                    android:valueFrom="20.0"
-                    android:valueTo="90.0"
+                    android:value="90"
+                    android:valueFrom="70.0"
+                    android:valueTo="140.0"
                     android:stepSize="1.0" />
             </LinearLayout>
         </ScrollView>


### PR DESCRIPTION
Closes #27

## Summary
- restore the older far-signal detection behavior while keeping the newer app structure
- fix the live preview overlay alignment so boxes track the actual object position more reliably
- clean up the debug tuning panel so it stays stable and both up/down tilt thresholds can be tuned independently

## What changed
- revert the risky cropped-analysis path back to full-frame traffic-light detection
- restore supported-device auto 2x zoom behavior to match the older tested default
- reproject overlay boxes through a shared preview viewport so the preview and analysis paths stay aligned
- stabilize the target/decision debug blocks with fixed placeholders instead of growing and shrinking when fields appear
- split the tilt tuning UI into separate down/up sliders and wire both to real runtime thresholds

## Testing
- `./gradlew.bat testDebugUnitTest`
- `./gradlew.bat lintDebug`
- `./gradlew.bat assembleDebug`
- installed updated debug APK on a connected Android device via `adb install --no-streaming -r`

## Reviewer focus
- whether far traffic-light recall matches the earlier onboarding-era build again
- whether overlay drift at the top/bottom of the preview is fixed without reintroducing the detection regression
- whether the debug panel remains stable and the two tilt sliders now control real thresholds