### PR TITLE
디버그 샘플 영상 리플레이 입력 모드 추가

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -8,13 +8,16 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.RectF
+import android.media.MediaMetadataRetriever
 import android.location.Location
 import android.location.LocationManager
+import android.net.Uri
 import android.os.Bundle
 import android.os.SystemClock
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -70,6 +73,8 @@ class MainActivity : AppCompatActivity() {
     private companion object {
         private const val CAMERA_COLD_START_TIMEOUT_MS = 3_500L
         private const val MAX_CAMERA_COLD_START_RECOVERIES = 1
+        private const val VIDEO_REPLAY_FRAME_INTERVAL_US = 200_000L
+        private const val VIDEO_REPLAY_FRAME_DELAY_MS = 200L
     }
 
     private data class StatusVisualState(
@@ -82,6 +87,7 @@ class MainActivity : AppCompatActivity() {
     )
 
     private lateinit var viewFinder: PreviewView
+    private lateinit var videoReplayFrameView: ImageView
     private lateinit var overlay: OverlayView
     private lateinit var fpsText: TextView
     private lateinit var avgFpsText: TextView
@@ -93,6 +99,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var modelNameText: TextView
     private lateinit var buildInfoText: TextView
     private lateinit var resetAppButton: MaterialButton
+    private lateinit var videoReplayButton: MaterialButton
     private lateinit var openGpsDebugMapButton: MaterialButton
     private lateinit var clearMapCacheButton: MaterialButton
     private lateinit var targetInfoText: TextView
@@ -133,6 +140,10 @@ class MainActivity : AppCompatActivity() {
     private var cameraManager: CameraManager? = null
     private var hasStartedCamera = false
     private var cameraRecoveryAttempts = 0
+    private val videoReplayRunning = AtomicBoolean(false)
+    private var videoReplayUri: Uri? = null
+    private var pendingReplayUriAfterDetectorInit: Uri? = null
+    private var inputRateLabel = "Camera FPS"
     @Volatile
     private var lastCameraFrameAtElapsedMs = 0L
 
@@ -205,6 +216,18 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+    private val pickVideoReplayLauncher =
+        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+            uri ?: return@registerForActivityResult
+            runCatching {
+                contentResolver.takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+            }
+            startVideoReplay(uri)
+        }
+
     // 7-class fine-tuned model labels. Only human_* labels drive pedestrian signal guidance.
     private val finetunedLabels = DetectionLabels.sevenClassLabels
 
@@ -236,6 +259,7 @@ class MainActivity : AppCompatActivity() {
         viewFinder = findViewById(R.id.viewFinder)
         viewFinder.implementationMode = PreviewView.ImplementationMode.COMPATIBLE
         viewFinder.scaleType = PreviewView.ScaleType.FILL_CENTER
+        videoReplayFrameView = findViewById(R.id.videoReplayFrameView)
         statusTintOverlay = findViewById(R.id.statusTintOverlay)
         overlay = findViewById(R.id.overlay)
         debugContainer = findViewById(R.id.debugContainer)
@@ -245,6 +269,7 @@ class MainActivity : AppCompatActivity() {
         statusPanel = findViewById(R.id.statusPanel)
         backendStatusText = findViewById(R.id.backendStatusText)
         resetAppButton = findViewById(R.id.resetAppButton)
+        videoReplayButton = findViewById(R.id.videoReplayButton)
         openGpsDebugMapButton = findViewById(R.id.openGpsDebugMapButton)
         clearMapCacheButton = findViewById(R.id.clearMapCacheButton)
         inputFpsText = findViewById(R.id.inputFpsText)
@@ -293,7 +318,15 @@ class MainActivity : AppCompatActivity() {
             debugToggleButton.contentDescription =
                 if (showDebugInfo) "디버그 정보 닫기" else "디버그 정보 열기"
         }
+        videoReplayButton.setOnClickListener {
+            if (videoReplayRunning.get()) {
+                stopVideoReplay(restoreCamera = true, clearSelectedVideo = true)
+            } else {
+                pickVideoReplayLauncher.launch(arrayOf("video/*"))
+            }
+        }
         resetAppButton.setOnClickListener {
+            stopVideoReplay(restoreCamera = false, clearSelectedVideo = true)
             detector?.close()
             detector = null
             cameraManager?.stopCamera()
@@ -401,6 +434,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onPause() {
+        stopVideoReplay(restoreCamera = false, clearSelectedVideo = false)
         guidanceRuntimeResetter.resetForPause()
         viewFinder.removeCallbacks(cameraColdStartRecoveryRunnable)
         crossingSupportManager.stop()
@@ -453,6 +487,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun applyModelSelection(selectedModel: String) {
+        val replayUriToResume = if (videoReplayRunning.get()) videoReplayUri else null
+        if (replayUriToResume != null) {
+            stopVideoReplay(restoreCamera = false, clearSelectedVideo = false)
+            pendingReplayUriAfterDetectorInit = replayUriToResume
+        }
+
         currentModelName = selectedModel
         currentModelProfile = InferenceModelProfile.fromFileName(selectedModel)
         reusableRotatedBitmap = null
@@ -529,7 +569,7 @@ class MainActivity : AppCompatActivity() {
         performanceTracker.update(inferenceTime, stageDurationsMs)
         
         // Update UI with results
-        inputFpsText.text = cameraRateTracker.rateStr
+        inputFpsText.text = cameraRateTracker.rateStr.replaceFirst("Camera FPS", inputRateLabel)
         fpsText.text = performanceTracker.currentFpsStr.replaceFirst("FPS", "Processed FPS")
         avgFpsText.text = performanceTracker.avgFpsStr.replaceFirst("Avg FPS", "Processed Avg FPS")
         avgLatencyText.text = performanceTracker.avgLatencyStr
@@ -592,7 +632,11 @@ class MainActivity : AppCompatActivity() {
                         "모델: $modelName (${newDetector.runtimeBackendLabel})"
                     Log.i("VIA_GPU", backendStatus)
                     publishBackendStatus("Backend: ${newDetector.runtimeBackendLabel}")
-                    if (restartCameraAfterInit && hasStartedCamera) {
+                    val pendingReplayUri = pendingReplayUriAfterDetectorInit
+                    if (pendingReplayUri != null) {
+                        pendingReplayUriAfterDetectorInit = null
+                        startVideoReplay(pendingReplayUri)
+                    } else if (restartCameraAfterInit && hasStartedCamera) {
                         startCamera()
                     }
                 }
@@ -619,6 +663,10 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun startCamera(isRecoveryRestart: Boolean = false) {
+        videoReplayRunning.set(false)
+        videoReplayFrameView.visibility = View.GONE
+        inputRateLabel = "Camera FPS"
+        videoReplayButton.text = "샘플 영상 선택"
         cameraManager?.stopCamera()
         hasStartedCamera = true
         if (!isRecoveryRestart) {
@@ -667,7 +715,125 @@ class MainActivity : AppCompatActivity() {
         val zoomRatio = if (zoomSwitch.isChecked && zoomSwitch.isEnabled) 2.0f else 1.0f
         cameraManager?.setZoom(zoomRatio)
     }
-    
+
+    private fun startVideoReplay(uri: Uri) {
+        val executor = processingExecutor ?: return
+        videoReplayUri = uri
+        videoReplayRunning.set(true)
+        inputRateLabel = "Replay FPS"
+        resetPerformanceStats()
+        guidanceRuntimeResetter.resetForTrafficLogicDisabled()
+        viewFinder.removeCallbacks(cameraColdStartRecoveryRunnable)
+        cameraManager?.stopCamera()
+        hasStartedCamera = false
+        pendingFrame.getAndSet(null)?.close()
+
+        videoReplayFrameView.visibility = View.VISIBLE
+        videoReplayButton.text = "샘플 영상 중지"
+        publishBackendStatus("Replay: sample video")
+        zoomSwitch.isEnabled = false
+        zoomSwitch.text = "2x Zoom (Replay)"
+
+        executor.execute {
+            val retriever = MediaMetadataRetriever()
+            try {
+                retriever.setDataSource(this, uri)
+                val durationUs =
+                    retriever
+                        .extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                        ?.toLongOrNull()
+                        ?.times(1_000L)
+                        ?: 0L
+                var timestampUs = 0L
+
+                while (videoReplayRunning.get()) {
+                    val frameStartNs = SystemClock.elapsedRealtimeNanos()
+                    val decodeStartNs = SystemClock.elapsedRealtimeNanos()
+                    val frame =
+                        retriever.getFrameAtTime(
+                            timestampUs,
+                            MediaMetadataRetriever.OPTION_CLOSEST
+                        )
+
+                    if (frame == null) {
+                        timestampUs = 0L
+                        continue
+                    }
+
+                    val bitmap =
+                        if (frame.config == Bitmap.Config.ARGB_8888) {
+                            frame
+                        } else {
+                            frame.copy(Bitmap.Config.ARGB_8888, false)
+                        }
+                    val stageDurationsMs =
+                        linkedMapOf("decode" to elapsedMillis(decodeStartNs))
+
+                    cameraRateTracker.mark()
+                    runOnUiThread {
+                        if (videoReplayRunning.get()) {
+                            videoReplayFrameView.setImageBitmap(bitmap)
+                        }
+                    }
+                    processBitmapFrame(
+                        bitmap = bitmap,
+                        frameStartNs = frameStartNs,
+                        stageDurationsMs = stageDurationsMs,
+                        analysisOutputTransform = null,
+                        useLiveContext = false
+                    )
+
+                    timestampUs += VIDEO_REPLAY_FRAME_INTERVAL_US
+                    if (durationUs > 0L && timestampUs >= durationUs) {
+                        timestampUs = 0L
+                    }
+                    Thread.sleep(VIDEO_REPLAY_FRAME_DELAY_MS)
+                }
+            } catch (e: Exception) {
+                Log.e("MainActivity", "Error replaying sample video", e)
+                runOnUiThread {
+                    Toast.makeText(
+                        this,
+                        "샘플 영상 재생 실패: ${e.message}",
+                        Toast.LENGTH_LONG
+                    ).show()
+                    stopVideoReplay(restoreCamera = true, clearSelectedVideo = true)
+                }
+            } finally {
+                runCatching { retriever.release() }
+            }
+        }
+    }
+
+    private fun stopVideoReplay(
+        restoreCamera: Boolean,
+        clearSelectedVideo: Boolean
+    ) {
+        videoReplayRunning.set(false)
+        if (clearSelectedVideo) {
+            videoReplayUri = null
+        }
+        pendingReplayUriAfterDetectorInit = null
+        if (!::videoReplayFrameView.isInitialized) {
+            return
+        }
+        videoReplayFrameView.visibility = View.GONE
+        videoReplayFrameView.setImageDrawable(null)
+        videoReplayButton.text = "샘플 영상 선택"
+        overlay.clear()
+        inputRateLabel = "Camera FPS"
+        resetPerformanceStats()
+        guidanceRuntimeResetter.resetForTrafficLogicDisabled()
+        publishBackendStatus("Backend: ${detector?.runtimeBackendLabel ?: "unknown"}")
+
+        if (restoreCamera &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            startCamera()
+        }
+    }
+     
     private fun enqueueFrame(imageProxy: ImageProxy) {
         lastCameraFrameAtElapsedMs = SystemClock.elapsedRealtime()
         cameraRateTracker.mark()
@@ -730,12 +896,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun processImage(imageProxy: ImageProxy) {
-        val activeDetector = detector
-        if (activeDetector == null) {
-            imageProxy.close()
-            return
-        }
-
         val stageDurationsMs = linkedMapOf<String, Long>()
         val frameStartNs = SystemClock.elapsedRealtimeNanos()
         var imageClosed = false
@@ -762,94 +922,112 @@ class MainActivity : AppCompatActivity() {
             }
             stageDurationsMs["rotate"] = elapsedMillis(rotateStartNs)
 
-            val detectStartNs = SystemClock.elapsedRealtimeNanos()
-            val result = activeDetector.detect(rotatedBitmap, confidenceThreshold)
-            stageDurationsMs["detect"] = elapsedMillis(detectStartNs)
-
-            val enableTrafficLogic = trafficLogicSwitch.isChecked
-            val crossingSupportSnapshot =
-                if (enableTrafficLogic) {
-                    crossingSupportManager.snapshot()
-                } else {
-                    CrossingSupportSnapshot()
-                }
-            val analyzeStartNs = SystemClock.elapsedRealtimeNanos()
-            val rawAnalysisResult = signalAnalyzer.analyze(
+            processBitmapFrame(
                 bitmap = rotatedBitmap,
-                rawBoxes = result.boxes,
-                enableTrafficLogic = enableTrafficLogic,
-                enableHighlight = highlightTargetSwitch.isChecked,
-                crossingSupportSnapshot = crossingSupportSnapshot
+                frameStartNs = frameStartNs,
+                stageDurationsMs = stageDurationsMs,
+                analysisOutputTransform = analysisOutputTransform,
+                useLiveContext = true
             )
-            val stabilizedAnalysisResult =
-                if (enableTrafficLogic) {
-                    rawAnalysisResult.withGuidanceSnapshot(
-                        guidanceStateStabilizer.stabilize(rawAnalysisResult.toGuidanceSnapshot())
-                    )
-                } else {
-                    guidanceStateStabilizer.reset()
-                    rawAnalysisResult
-                }
-            val analysisResult =
-                if (enableTrafficLogic) {
-                    stabilizedAnalysisResult.withAdvisoryAssessment(
-                        advisoryEvaluator.evaluate(stabilizedAnalysisResult)
-                    )
-                } else {
-                    stabilizedAnalysisResult
-                }
-            stageDurationsMs["analyze"] = elapsedMillis(analyzeStartNs)
-
-            runOnUiThread {
-                val uiStartNs = SystemClock.elapsedRealtimeNanos()
-                latestCrossingSupportSnapshot = analysisResult.crossingSupportSnapshot
-                renderOverlay(
-                    bitmap = rotatedBitmap,
-                    analysisResult = analysisResult,
-                    showRawBoxes = rawDetectionSwitch.isChecked,
-                    analysisOutputTransform = analysisOutputTransform
-                )
-                updateTargetInfo(analysisResult, enableTrafficLogic)
-                updateDecisionDebugInfo(analysisResult, enableTrafficLogic)
-                updateGpsDebugMapButtonState()
-                updateUserStatus(analysisResult, enableTrafficLogic)
-                updateStatusVisuals(analysisResult, enableTrafficLogic)
-                logDecisionIfChanged(analysisResult, enableTrafficLogic)
-                logMapIfChanged(analysisResult.crossingSupportSnapshot)
-
-                if (enableTrafficLogic) {
-                    crossingSupportManager.setCrossingWindowActive(
-                        analysisResult.guidancePhase == GuidancePhase.WALK_ALLOWED
-                    )
-                    feedbackManager.onAdvisoryChanged(
-                        AdvisoryAssessment(
-                            state = analysisResult.advisoryState,
-                            confidenceLevel = analysisResult.advisoryConfidenceLevel,
-                            confidenceScore = analysisResult.advisoryConfidenceScore,
-                            confidenceReasons = analysisResult.advisoryConfidenceReasons,
-                            titleText = analysisResult.advisoryTitleText,
-                            detailText = analysisResult.advisoryDetailText,
-                            speechText = analysisResult.advisorySpeechText
-                        )
-                    )
-                } else {
-                    crossingSupportManager.setCrossingWindowActive(false)
-                    feedbackManager.clearState()
-                }
-
-                stageDurationsMs["ui"] = elapsedMillis(uiStartNs)
-                updateDebugInfo(
-                    inferenceTime = result.inferenceTime,
-                    totalLatencyMs = elapsedMillis(frameStartNs),
-                    stageDurationsMs = stageDurationsMs
-                )
-            }
         } catch (e: Exception) {
             Log.e("MainActivity", "Error processing camera frame", e)
         } finally {
             if (!imageClosed) {
                 imageProxy.close()
             }
+        }
+    }
+
+    private fun processBitmapFrame(
+        bitmap: Bitmap,
+        frameStartNs: Long,
+        stageDurationsMs: LinkedHashMap<String, Long>,
+        analysisOutputTransform: OutputTransform?,
+        useLiveContext: Boolean
+    ) {
+        val activeDetector = detector ?: return
+
+        val detectStartNs = SystemClock.elapsedRealtimeNanos()
+        val result = activeDetector.detect(bitmap, confidenceThreshold)
+        stageDurationsMs["detect"] = elapsedMillis(detectStartNs)
+
+        val enableTrafficLogic = trafficLogicSwitch.isChecked
+        val crossingSupportSnapshot =
+            if (enableTrafficLogic && useLiveContext) {
+                crossingSupportManager.snapshot()
+            } else {
+                CrossingSupportSnapshot()
+            }
+        val analyzeStartNs = SystemClock.elapsedRealtimeNanos()
+        val rawAnalysisResult = signalAnalyzer.analyze(
+            bitmap = bitmap,
+            rawBoxes = result.boxes,
+            enableTrafficLogic = enableTrafficLogic,
+            enableHighlight = highlightTargetSwitch.isChecked,
+            crossingSupportSnapshot = crossingSupportSnapshot
+        )
+        val stabilizedAnalysisResult =
+            if (enableTrafficLogic) {
+                rawAnalysisResult.withGuidanceSnapshot(
+                    guidanceStateStabilizer.stabilize(rawAnalysisResult.toGuidanceSnapshot())
+                )
+            } else {
+                guidanceStateStabilizer.reset()
+                rawAnalysisResult
+            }
+        val analysisResult =
+            if (enableTrafficLogic) {
+                stabilizedAnalysisResult.withAdvisoryAssessment(
+                    advisoryEvaluator.evaluate(stabilizedAnalysisResult)
+                )
+            } else {
+                stabilizedAnalysisResult
+            }
+        stageDurationsMs["analyze"] = elapsedMillis(analyzeStartNs)
+
+        runOnUiThread {
+            val uiStartNs = SystemClock.elapsedRealtimeNanos()
+            latestCrossingSupportSnapshot = analysisResult.crossingSupportSnapshot
+            renderOverlay(
+                bitmap = bitmap,
+                analysisResult = analysisResult,
+                showRawBoxes = rawDetectionSwitch.isChecked,
+                analysisOutputTransform = analysisOutputTransform
+            )
+            updateTargetInfo(analysisResult, enableTrafficLogic)
+            updateDecisionDebugInfo(analysisResult, enableTrafficLogic)
+            updateGpsDebugMapButtonState()
+            updateUserStatus(analysisResult, enableTrafficLogic)
+            updateStatusVisuals(analysisResult, enableTrafficLogic)
+            logDecisionIfChanged(analysisResult, enableTrafficLogic)
+            logMapIfChanged(analysisResult.crossingSupportSnapshot)
+
+            if (enableTrafficLogic) {
+                crossingSupportManager.setCrossingWindowActive(
+                    useLiveContext && analysisResult.guidancePhase == GuidancePhase.WALK_ALLOWED
+                )
+                feedbackManager.onAdvisoryChanged(
+                    AdvisoryAssessment(
+                        state = analysisResult.advisoryState,
+                        confidenceLevel = analysisResult.advisoryConfidenceLevel,
+                        confidenceScore = analysisResult.advisoryConfidenceScore,
+                        confidenceReasons = analysisResult.advisoryConfidenceReasons,
+                        titleText = analysisResult.advisoryTitleText,
+                        detailText = analysisResult.advisoryDetailText,
+                        speechText = analysisResult.advisorySpeechText
+                    )
+                )
+            } else {
+                crossingSupportManager.setCrossingWindowActive(false)
+                feedbackManager.clearState()
+            }
+
+            stageDurationsMs["ui"] = elapsedMillis(uiStartNs)
+            updateDebugInfo(
+                inferenceTime = result.inferenceTime,
+                totalLatencyMs = elapsedMillis(frameStartNs),
+                stageDurationsMs = stageDurationsMs
+            )
         }
     }
 
@@ -1224,7 +1402,7 @@ class MainActivity : AppCompatActivity() {
     private fun resetPerformanceStats() {
         performanceTracker.clear()
         cameraRateTracker.clear()
-        inputFpsText.text = "Camera FPS: 0"
+        inputFpsText.text = "$inputRateLabel: 0"
         avgFpsText.text = "Processed Avg FPS: 0"
         avgLatencyText.text = "Avg Latency: 0ms"
         fpsText.text = "Processed FPS: 0"
@@ -1262,6 +1440,7 @@ class MainActivity : AppCompatActivity() {
         hasStartedCamera = false
         viewFinder.removeCallbacks(cameraColdStartRecoveryRunnable)
         cameraRecoveryAttempts = 0
+        videoReplayRunning.set(false)
         lastCameraFrameAtElapsedMs = 0L
         pendingFrame.getAndSet(null)?.close()
         cameraExecutor?.shutdown()

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -116,9 +116,11 @@ class MainActivity : AppCompatActivity() {
     private lateinit var confidenceSliderLabel: TextView
     private lateinit var trafficConfidenceLabel: TextView
     private lateinit var downTiltLabel: TextView
+    private lateinit var upTiltLabel: TextView
     private lateinit var confidenceSlider: Slider
     private lateinit var trafficConfidenceSlider: Slider
     private lateinit var downTiltSlider: Slider
+    private lateinit var upTiltSlider: Slider
     private lateinit var gpuSwitch: com.google.android.material.switchmaterial.SwitchMaterial
     private lateinit var zoomSwitch: androidx.appcompat.widget.SwitchCompat
     private lateinit var rawDetectionSwitch: androidx.appcompat.widget.SwitchCompat
@@ -296,9 +298,11 @@ class MainActivity : AppCompatActivity() {
         confidenceSliderLabel = findViewById(R.id.confidenceSliderLabel)
         trafficConfidenceLabel = findViewById(R.id.trafficConfidenceLabel)
         downTiltLabel = findViewById(R.id.downTiltLabel)
+        upTiltLabel = findViewById(R.id.upTiltLabel)
         confidenceSlider = findViewById(R.id.confidenceSlider)
         trafficConfidenceSlider = findViewById(R.id.trafficConfidenceSlider)
         downTiltSlider = findViewById(R.id.downTiltSlider)
+        upTiltSlider = findViewById(R.id.upTiltSlider)
         gpuSwitch = findViewById(R.id.gpuSwitch)
         zoomSwitch = findViewById(R.id.swZoom2x)
         rawDetectionSwitch = findViewById(R.id.swRawDetection)
@@ -369,12 +373,20 @@ class MainActivity : AppCompatActivity() {
             updateDownTiltLabel()
             updateTuningDebugText()
         }
+        upTiltSlider.addOnChangeListener { _, value, _ ->
+            crossingSupportManager.updateLookingUpThresholdDegrees(value)
+            updateUpTiltLabel()
+            updateTuningDebugText()
+        }
 
         confidenceSlider.value = 0.5f
         trafficConfidenceSlider.value = 0.15f
-        downTiltSlider.value = 20f
-        downTiltSlider.isEnabled = false
+        downTiltSlider.value = crossingSupportManager.currentLookingDownThresholdDegrees()
+        upTiltSlider.value = crossingSupportManager.currentLookingUpThresholdDegrees()
+        downTiltSlider.isEnabled = true
+        upTiltSlider.isEnabled = true
         updateDownTiltLabel()
+        updateUpTiltLabel()
 
         gpuSwitch.setOnCheckedChangeListener { _, isChecked ->
             if (suppressGpuToggleCallback) {
@@ -557,11 +569,19 @@ class MainActivity : AppCompatActivity() {
 
     private fun updateTuningDebugText() {
         tuningDebugText.text =
-            "Tuning: ${GuidanceTuningDefaults.toDebugSummary()}, tilt raw down=-160..-90, up=90..120"
+            "Tuning: ${GuidanceTuningDefaults.toDebugSummary()}, tilt raw down=-160..-" +
+                "${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingDownThresholdDegrees())}, " +
+                "up=90..${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingUpThresholdDegrees())}"
     }
 
     private fun updateDownTiltLabel() {
-        downTiltLabel.text = "Tilt Raw Range: down -160..-90 / up 90..120"
+        downTiltLabel.text =
+            "Down Tilt Range: -160..-${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingDownThresholdDegrees())}"
+    }
+
+    private fun updateUpTiltLabel() {
+        upTiltLabel.text =
+            "Up Tilt Range: 90..${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingUpThresholdDegrees())}"
     }
 
     private fun updateDebugInfo(
@@ -720,6 +740,13 @@ class MainActivity : AppCompatActivity() {
 
     private fun applySelectedZoom() {
         val zoomRatio = if (zoomSwitch.isChecked && zoomSwitch.isEnabled) 2.0f else 1.0f
+        if (videoReplayRunning.get()) {
+            videoReplayFrameView.pivotX = videoReplayFrameView.width / 2f
+            videoReplayFrameView.pivotY = videoReplayFrameView.height / 2f
+            videoReplayFrameView.scaleX = zoomRatio
+            videoReplayFrameView.scaleY = zoomRatio
+            return
+        }
         cameraManager?.setZoom(zoomRatio)
     }
 
@@ -739,8 +766,9 @@ class MainActivity : AppCompatActivity() {
         videoReplayFrameView.visibility = View.VISIBLE
         videoReplayButton.text = "샘플 영상 중지"
         publishBackendStatus("Replay: preparing video input")
-        zoomSwitch.isEnabled = false
-        zoomSwitch.text = "2x Zoom (Replay)"
+        zoomSwitch.isEnabled = true
+        zoomSwitch.text = "Use 2x Zoom (Replay)"
+        applySelectedZoom()
         prepareVideoReplayPlayer(uri)
 
         executor.execute {
@@ -874,7 +902,8 @@ class MainActivity : AppCompatActivity() {
         runOnUiThread {
             try {
                 if (videoReplayRunning.get() && videoReplayFrameView.isAvailable) {
-                    bitmapRef.set(videoReplayFrameView.getBitmap(width, height))
+                    val replayBitmap = videoReplayFrameView.getBitmap(width, height)
+                    bitmapRef.set(applyReplayZoomCropIfNeeded(replayBitmap, width, height))
                 }
             } finally {
                 latch.countDown()
@@ -882,6 +911,22 @@ class MainActivity : AppCompatActivity() {
         }
         latch.await(VIDEO_REPLAY_CAPTURE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
         return bitmapRef.get()
+    }
+
+    private fun applyReplayZoomCropIfNeeded(
+        bitmap: Bitmap?,
+        outputWidth: Int,
+        outputHeight: Int
+    ): Bitmap? {
+        if (bitmap == null || !zoomSwitch.isChecked || !zoomSwitch.isEnabled) {
+            return bitmap
+        }
+        val cropWidth = (bitmap.width / 2).coerceAtLeast(1)
+        val cropHeight = (bitmap.height / 2).coerceAtLeast(1)
+        val left = ((bitmap.width - cropWidth) / 2).coerceAtLeast(0)
+        val top = ((bitmap.height - cropHeight) / 2).coerceAtLeast(0)
+        val cropped = Bitmap.createBitmap(bitmap, left, top, cropWidth, cropHeight)
+        return Bitmap.createScaledBitmap(cropped, outputWidth, outputHeight, true)
     }
 
     private fun releaseVideoReplayPlayer() {
@@ -912,6 +957,8 @@ class MainActivity : AppCompatActivity() {
         }
         releaseVideoReplayPlayer()
         videoReplayFrameView.surfaceTextureListener = null
+        videoReplayFrameView.scaleX = 1f
+        videoReplayFrameView.scaleY = 1f
         videoReplayFrameView.visibility = View.GONE
         viewFinder.visibility = View.VISIBLE
         videoReplayButton.text = "샘플 영상 선택"

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -773,7 +773,8 @@ class MainActivity : AppCompatActivity() {
                         frameStartNs = frameStartNs,
                         stageDurationsMs = stageDurationsMs,
                         analysisOutputTransform = null,
-                        useLiveContext = false
+                        useLiveContext = false,
+                        mapOverlayDirectlyToView = true
                     )
 
                     val elapsedMs = elapsedMillis(frameStartNs)
@@ -1021,7 +1022,8 @@ class MainActivity : AppCompatActivity() {
                 frameStartNs = frameStartNs,
                 stageDurationsMs = stageDurationsMs,
                 analysisOutputTransform = analysisOutputTransform,
-                useLiveContext = true
+                useLiveContext = true,
+                mapOverlayDirectlyToView = false
             )
         } catch (e: Exception) {
             Log.e("MainActivity", "Error processing camera frame", e)
@@ -1037,7 +1039,8 @@ class MainActivity : AppCompatActivity() {
         frameStartNs: Long,
         stageDurationsMs: LinkedHashMap<String, Long>,
         analysisOutputTransform: OutputTransform?,
-        useLiveContext: Boolean
+        useLiveContext: Boolean,
+        mapOverlayDirectlyToView: Boolean
     ) {
         val activeDetector = detector ?: return
 
@@ -1086,7 +1089,8 @@ class MainActivity : AppCompatActivity() {
                 bitmap = bitmap,
                 analysisResult = analysisResult,
                 showRawBoxes = rawDetectionSwitch.isChecked,
-                analysisOutputTransform = analysisOutputTransform
+                analysisOutputTransform = analysisOutputTransform,
+                mapOverlayDirectlyToView = mapOverlayDirectlyToView
             )
             updateTargetInfo(analysisResult, enableTrafficLogic)
             updateDecisionDebugInfo(analysisResult, enableTrafficLogic)
@@ -1129,16 +1133,21 @@ class MainActivity : AppCompatActivity() {
         bitmap: Bitmap,
         analysisResult: SignalAnalysisResult,
         showRawBoxes: Boolean,
-        analysisOutputTransform: OutputTransform?
+        analysisOutputTransform: OutputTransform?,
+        mapOverlayDirectlyToView: Boolean
     ) {
         if (showRawBoxes && showBBoxOverlay) {
             val mappedBoxes =
-                mapBoxesToPreviewView(
-                    boxes = analysisResult.boxesToShow,
-                    sourceWidth = bitmap.width.toFloat(),
-                    sourceHeight = bitmap.height.toFloat(),
-                    analysisOutputTransform = analysisOutputTransform
-                )
+                if (mapOverlayDirectlyToView) {
+                    mapNormalizedBoxesDirectlyToOverlay(analysisResult.boxesToShow)
+                } else {
+                    mapBoxesToPreviewView(
+                        boxes = analysisResult.boxesToShow,
+                        sourceWidth = bitmap.width.toFloat(),
+                        sourceHeight = bitmap.height.toFloat(),
+                        analysisOutputTransform = analysisOutputTransform
+                    )
+                }
             if (mappedBoxes != null) {
                 overlay.setResults(mappedBoxes, inViewCoordinates = true)
             } else {
@@ -1147,6 +1156,27 @@ class MainActivity : AppCompatActivity() {
             }
         } else {
             overlay.setResults(emptyList(), inViewCoordinates = true)
+        }
+    }
+
+    private fun mapNormalizedBoxesDirectlyToOverlay(
+        boxes: List<OverlayView.BoundingBox>
+    ): List<OverlayView.BoundingBox> {
+        val viewWidth = overlay.width.toFloat().takeIf { it > 0f } ?: videoReplayFrameView.width.toFloat()
+        val viewHeight = overlay.height.toFloat().takeIf { it > 0f } ?: videoReplayFrameView.height.toFloat()
+        return boxes.map { box ->
+            OverlayView.BoundingBox(
+                box = RectF(
+                    box.box.left * viewWidth,
+                    box.box.top * viewHeight,
+                    box.box.right * viewWidth,
+                    box.box.bottom * viewHeight
+                ),
+                clsName = box.clsName,
+                score = box.score,
+                debugRatio = box.debugRatio,
+                isTarget = box.isTarget
+            )
         }
     }
 

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -77,7 +77,7 @@ class MainActivity : AppCompatActivity() {
     private companion object {
         private const val CAMERA_COLD_START_TIMEOUT_MS = 3_500L
         private const val MAX_CAMERA_COLD_START_RECOVERIES = 1
-        private const val VIDEO_REPLAY_FRAME_DELAY_MS = 33L
+        private const val VIDEO_REPLAY_TARGET_FRAME_INTERVAL_MS = 33L
         private const val VIDEO_REPLAY_CAPTURE_TIMEOUT_MS = 250L
     }
 
@@ -776,7 +776,12 @@ class MainActivity : AppCompatActivity() {
                         useLiveContext = false
                     )
 
-                    Thread.sleep(VIDEO_REPLAY_FRAME_DELAY_MS)
+                    val elapsedMs = elapsedMillis(frameStartNs)
+                    val remainingFrameBudgetMs =
+                        VIDEO_REPLAY_TARGET_FRAME_INTERVAL_MS - elapsedMs
+                    if (remainingFrameBudgetMs > 0L) {
+                        Thread.sleep(remainingFrameBudgetMs)
+                    }
                 }
             } catch (e: Exception) {
                 Log.e("MainActivity", "Error replaying sample video", e)

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -12,14 +12,15 @@ import android.media.MediaMetadataRetriever
 import android.location.Location
 import android.location.LocationManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
+import android.widget.VideoView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.ImageProxy
@@ -87,7 +88,7 @@ class MainActivity : AppCompatActivity() {
     )
 
     private lateinit var viewFinder: PreviewView
-    private lateinit var videoReplayFrameView: ImageView
+    private lateinit var videoReplayFrameView: VideoView
     private lateinit var overlay: OverlayView
     private lateinit var fpsText: TextView
     private lateinit var avgFpsText: TextView
@@ -665,6 +666,7 @@ class MainActivity : AppCompatActivity() {
     private fun startCamera(isRecoveryRestart: Boolean = false) {
         videoReplayRunning.set(false)
         videoReplayFrameView.visibility = View.GONE
+        viewFinder.visibility = View.VISIBLE
         inputRateLabel = "Camera FPS"
         videoReplayButton.text = "샘플 영상 선택"
         cameraManager?.stopCamera()
@@ -728,7 +730,17 @@ class MainActivity : AppCompatActivity() {
         hasStartedCamera = false
         pendingFrame.getAndSet(null)?.close()
 
+        viewFinder.visibility = View.GONE
         videoReplayFrameView.visibility = View.VISIBLE
+        videoReplayFrameView.setVideoURI(uri)
+        videoReplayFrameView.setOnPreparedListener { player ->
+            player.isLooping = true
+            videoReplayFrameView.start()
+        }
+        videoReplayFrameView.setOnErrorListener { _, what, extra ->
+            Log.w("VIA_REPLAY", "VideoView playback error what=$what extra=$extra")
+            false
+        }
         videoReplayButton.text = "샘플 영상 중지"
         publishBackendStatus("Replay: sample video")
         zoomSwitch.isEnabled = false
@@ -749,11 +761,7 @@ class MainActivity : AppCompatActivity() {
                 while (videoReplayRunning.get()) {
                     val frameStartNs = SystemClock.elapsedRealtimeNanos()
                     val decodeStartNs = SystemClock.elapsedRealtimeNanos()
-                    val frame =
-                        retriever.getFrameAtTime(
-                            timestampUs,
-                            MediaMetadataRetriever.OPTION_CLOSEST
-                        )
+                    val frame = extractReplayFrame(retriever, timestampUs)
 
                     if (frame == null) {
                         timestampUs = 0L
@@ -770,11 +778,6 @@ class MainActivity : AppCompatActivity() {
                         linkedMapOf("decode" to elapsedMillis(decodeStartNs))
 
                     cameraRateTracker.mark()
-                    runOnUiThread {
-                        if (videoReplayRunning.get()) {
-                            videoReplayFrameView.setImageBitmap(bitmap)
-                        }
-                    }
                     processBitmapFrame(
                         bitmap = bitmap,
                         frameStartNs = frameStartNs,
@@ -805,6 +808,28 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    private fun extractReplayFrame(
+        retriever: MediaMetadataRetriever,
+        timestampUs: Long
+    ): Bitmap? {
+        val targetWidth = currentModelProfile.analysisResolution.width
+        val targetHeight = currentModelProfile.analysisResolution.height
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            retriever.getScaledFrameAtTime(
+                timestampUs,
+                MediaMetadataRetriever.OPTION_CLOSEST,
+                targetWidth,
+                targetHeight
+            )
+        } else {
+            retriever
+                .getFrameAtTime(timestampUs, MediaMetadataRetriever.OPTION_CLOSEST)
+                ?.let { frame ->
+                    Bitmap.createScaledBitmap(frame, targetWidth, targetHeight, true)
+                }
+        }
+    }
+
     private fun stopVideoReplay(
         restoreCamera: Boolean,
         clearSelectedVideo: Boolean
@@ -817,8 +842,9 @@ class MainActivity : AppCompatActivity() {
         if (!::videoReplayFrameView.isInitialized) {
             return
         }
+        videoReplayFrameView.stopPlayback()
         videoReplayFrameView.visibility = View.GONE
-        videoReplayFrameView.setImageDrawable(null)
+        viewFinder.visibility = View.VISIBLE
         videoReplayButton.text = "샘플 영상 선택"
         overlay.clear()
         inputRateLabel = "Camera FPS"

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -8,19 +8,20 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.RectF
-import android.media.MediaMetadataRetriever
+import android.graphics.SurfaceTexture
 import android.location.Location
 import android.location.LocationManager
+import android.media.MediaPlayer
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
 import android.util.Log
+import android.view.Surface
+import android.view.TextureView
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
-import android.widget.VideoView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.ImageProxy
@@ -67,15 +68,17 @@ import kr.co.gachon.pproject6.via.util.PerformanceTracker
 import kr.co.gachon.pproject6.via.util.RateTracker
 import org.tensorflow.lite.gpu.CompatibilityList
 import java.util.Locale
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.TimeUnit
 
 class MainActivity : AppCompatActivity() {
     private companion object {
         private const val CAMERA_COLD_START_TIMEOUT_MS = 3_500L
         private const val MAX_CAMERA_COLD_START_RECOVERIES = 1
-        private const val VIDEO_REPLAY_FRAME_INTERVAL_US = 200_000L
-        private const val VIDEO_REPLAY_FRAME_DELAY_MS = 200L
+        private const val VIDEO_REPLAY_FRAME_DELAY_MS = 33L
+        private const val VIDEO_REPLAY_CAPTURE_TIMEOUT_MS = 250L
     }
 
     private data class StatusVisualState(
@@ -88,7 +91,7 @@ class MainActivity : AppCompatActivity() {
     )
 
     private lateinit var viewFinder: PreviewView
-    private lateinit var videoReplayFrameView: VideoView
+    private lateinit var videoReplayFrameView: TextureView
     private lateinit var overlay: OverlayView
     private lateinit var fpsText: TextView
     private lateinit var avgFpsText: TextView
@@ -144,6 +147,8 @@ class MainActivity : AppCompatActivity() {
     private val videoReplayRunning = AtomicBoolean(false)
     private var videoReplayUri: Uri? = null
     private var pendingReplayUriAfterDetectorInit: Uri? = null
+    private var videoReplayPlayer: MediaPlayer? = null
+    private var videoReplaySurface: Surface? = null
     private var inputRateLabel = "Camera FPS"
     @Volatile
     private var lastCameraFrameAtElapsedMs = 0L
@@ -732,50 +737,35 @@ class MainActivity : AppCompatActivity() {
 
         viewFinder.visibility = View.GONE
         videoReplayFrameView.visibility = View.VISIBLE
-        videoReplayFrameView.setVideoURI(uri)
-        videoReplayFrameView.setOnPreparedListener { player ->
-            player.isLooping = true
-            videoReplayFrameView.start()
-        }
-        videoReplayFrameView.setOnErrorListener { _, what, extra ->
-            Log.w("VIA_REPLAY", "VideoView playback error what=$what extra=$extra")
-            false
-        }
         videoReplayButton.text = "샘플 영상 중지"
-        publishBackendStatus("Replay: sample video")
+        publishBackendStatus("Replay: preparing video input")
         zoomSwitch.isEnabled = false
         zoomSwitch.text = "2x Zoom (Replay)"
+        prepareVideoReplayPlayer(uri)
 
         executor.execute {
-            val retriever = MediaMetadataRetriever()
             try {
-                retriever.setDataSource(this, uri)
-                val durationUs =
-                    retriever
-                        .extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
-                        ?.toLongOrNull()
-                        ?.times(1_000L)
-                        ?: 0L
-                var timestampUs = 0L
-
                 while (videoReplayRunning.get()) {
-                    val frameStartNs = SystemClock.elapsedRealtimeNanos()
-                    val decodeStartNs = SystemClock.elapsedRealtimeNanos()
-                    val frame = extractReplayFrame(retriever, timestampUs)
-
-                    if (frame == null) {
-                        timestampUs = 0L
+                    if (!videoReplayFrameView.isAvailable || detector == null) {
+                        Thread.sleep(50L)
                         continue
                     }
 
-                    val bitmap =
-                        if (frame.config == Bitmap.Config.ARGB_8888) {
-                            frame
-                        } else {
-                            frame.copy(Bitmap.Config.ARGB_8888, false)
-                        }
+                    val frameStartNs = SystemClock.elapsedRealtimeNanos()
+                    val captureStartNs = SystemClock.elapsedRealtimeNanos()
+                    val resolution = currentModelProfile.analysisResolution
+                    val bitmap = captureReplayBitmap(
+                        width = resolution.width,
+                        height = resolution.height
+                    )
+
+                    if (bitmap == null) {
+                        Thread.sleep(50L)
+                        continue
+                    }
+
                     val stageDurationsMs =
-                        linkedMapOf("decode" to elapsedMillis(decodeStartNs))
+                        linkedMapOf("capture" to elapsedMillis(captureStartNs))
 
                     cameraRateTracker.mark()
                     processBitmapFrame(
@@ -786,10 +776,6 @@ class MainActivity : AppCompatActivity() {
                         useLiveContext = false
                     )
 
-                    timestampUs += VIDEO_REPLAY_FRAME_INTERVAL_US
-                    if (durationUs > 0L && timestampUs >= durationUs) {
-                        timestampUs = 0L
-                    }
                     Thread.sleep(VIDEO_REPLAY_FRAME_DELAY_MS)
                 }
             } catch (e: Exception) {
@@ -802,32 +788,108 @@ class MainActivity : AppCompatActivity() {
                     ).show()
                     stopVideoReplay(restoreCamera = true, clearSelectedVideo = true)
                 }
-            } finally {
-                runCatching { retriever.release() }
             }
         }
     }
 
-    private fun extractReplayFrame(
-        retriever: MediaMetadataRetriever,
-        timestampUs: Long
-    ): Bitmap? {
-        val targetWidth = currentModelProfile.analysisResolution.width
-        val targetHeight = currentModelProfile.analysisResolution.height
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
-            retriever.getScaledFrameAtTime(
-                timestampUs,
-                MediaMetadataRetriever.OPTION_CLOSEST,
-                targetWidth,
-                targetHeight
-            )
+    private fun prepareVideoReplayPlayer(uri: Uri) {
+        releaseVideoReplayPlayer()
+
+        fun attach(surfaceTexture: SurfaceTexture) {
+            val surface = Surface(surfaceTexture)
+            videoReplaySurface = surface
+            val player = MediaPlayer()
+            videoReplayPlayer = player
+            try {
+                player.setDataSource(this, uri)
+                player.setSurface(surface)
+                player.isLooping = true
+                player.setOnPreparedListener {
+                    if (videoReplayRunning.get()) {
+                        it.start()
+                        publishBackendStatus("Replay: video input")
+                    }
+                }
+                player.setOnErrorListener { _, what, extra ->
+                    Log.w("VIA_REPLAY", "MediaPlayer playback error what=$what extra=$extra")
+                    Toast.makeText(
+                        this,
+                        "샘플 영상 재생 실패: $what/$extra",
+                        Toast.LENGTH_LONG
+                    ).show()
+                    stopVideoReplay(restoreCamera = true, clearSelectedVideo = true)
+                    true
+                }
+                player.prepareAsync()
+            } catch (e: Exception) {
+                Log.e("VIA_REPLAY", "Failed to prepare sample video", e)
+                Toast.makeText(this, "샘플 영상 준비 실패: ${e.message}", Toast.LENGTH_LONG).show()
+                stopVideoReplay(restoreCamera = true, clearSelectedVideo = true)
+            }
+        }
+
+        if (videoReplayFrameView.isAvailable) {
+            videoReplayFrameView.surfaceTexture?.let(::attach)
         } else {
-            retriever
-                .getFrameAtTime(timestampUs, MediaMetadataRetriever.OPTION_CLOSEST)
-                ?.let { frame ->
-                    Bitmap.createScaledBitmap(frame, targetWidth, targetHeight, true)
+            videoReplayFrameView.surfaceTextureListener =
+                object : TextureView.SurfaceTextureListener {
+                    override fun onSurfaceTextureAvailable(
+                        surface: SurfaceTexture,
+                        width: Int,
+                        height: Int
+                    ) {
+                        attach(surface)
+                    }
+
+                    override fun onSurfaceTextureSizeChanged(
+                        surface: SurfaceTexture,
+                        width: Int,
+                        height: Int
+                    ) = Unit
+
+                    override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
+                        videoReplayRunning.set(false)
+                        releaseVideoReplayPlayer()
+                        return true
+                    }
+
+                    override fun onSurfaceTextureUpdated(surface: SurfaceTexture) = Unit
                 }
         }
+    }
+
+    private fun captureReplayBitmap(width: Int, height: Int): Bitmap? {
+        if (!videoReplayRunning.get()) {
+            return null
+        }
+
+        val latch = CountDownLatch(1)
+        val bitmapRef = AtomicReference<Bitmap?>()
+        runOnUiThread {
+            try {
+                if (videoReplayRunning.get() && videoReplayFrameView.isAvailable) {
+                    bitmapRef.set(videoReplayFrameView.getBitmap(width, height))
+                }
+            } finally {
+                latch.countDown()
+            }
+        }
+        latch.await(VIDEO_REPLAY_CAPTURE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        return bitmapRef.get()
+    }
+
+    private fun releaseVideoReplayPlayer() {
+        videoReplayPlayer?.let { player ->
+            runCatching {
+                if (player.isPlaying) {
+                    player.stop()
+                }
+            }
+            runCatching { player.release() }
+        }
+        videoReplayPlayer = null
+        videoReplaySurface?.release()
+        videoReplaySurface = null
     }
 
     private fun stopVideoReplay(
@@ -842,7 +904,8 @@ class MainActivity : AppCompatActivity() {
         if (!::videoReplayFrameView.isInitialized) {
             return
         }
-        videoReplayFrameView.stopPlayback()
+        releaseVideoReplayPlayer()
+        videoReplayFrameView.surfaceTextureListener = null
         videoReplayFrameView.visibility = View.GONE
         viewFinder.visibility = View.VISIBLE
         videoReplayButton.text = "샘플 영상 선택"

--- a/app/src/main/java/kr/co/gachon/pproject6/via/context/CrossingSupportManager.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/context/CrossingSupportManager.kt
@@ -46,6 +46,10 @@ class CrossingSupportManager(
     private var gpsRegistered = false
     private var networkRegistered = false
     private var lastHeadingDegrees: Float? = null
+    private var lookingDownRawTiltRangeStartDegrees = config.lookingDownRawTiltRangeStartDegrees
+    private var lookingDownRawTiltRangeEndDegrees = config.lookingDownRawTiltRangeEndDegrees
+    private var lookingUpRawTiltRangeStartDegrees = config.lookingUpRawTiltRangeStartDegrees
+    private var lookingUpRawTiltRangeEndDegrees = config.lookingUpRawTiltRangeEndDegrees
     private val mapProximityManager = MapProximityManager(appContext, timeProvider)
 
     private val locationListener = LocationListener { location ->
@@ -76,11 +80,19 @@ class CrossingSupportManager(
         unregisterLocationUpdates()
     }
 
-    fun updateLookingDownThresholdDegrees(value: Float) = Unit
+    fun updateLookingDownThresholdDegrees(value: Float) {
+        val clampedThresholdDegrees = value.coerceIn(70f, 140f)
+        lookingDownRawTiltRangeEndDegrees = -clampedThresholdDegrees
+    }
 
-    fun currentLookingDownThresholdDegrees(): Float = config.lookingDownRawTiltRangeStartDegrees
+    fun currentLookingDownThresholdDegrees(): Float = abs(lookingDownRawTiltRangeEndDegrees)
 
-    fun currentLookingUpThresholdDegrees(): Float = config.lookingUpRawTiltRangeEndDegrees
+    fun updateLookingUpThresholdDegrees(value: Float) {
+        val clampedThresholdDegrees = value.coerceIn(90f, 170f)
+        lookingUpRawTiltRangeEndDegrees = clampedThresholdDegrees
+    }
+
+    fun currentLookingUpThresholdDegrees(): Float = lookingUpRawTiltRangeEndDegrees
 
     fun setCrossingWindowActive(isActive: Boolean) {
         val now = timeProvider()
@@ -230,7 +242,7 @@ class CrossingSupportManager(
                 val tiltDegrees = abs(signedTiltDegrees)
                 currentSignedTiltDegrees = signedTiltDegrees
                 currentTiltDegrees = tiltDegrees
-                if (signedTiltDegrees in config.lookingDownRawTiltRangeStartDegrees..config.lookingDownRawTiltRangeEndDegrees) {
+                if (signedTiltDegrees in lookingDownRawTiltRangeStartDegrees..lookingDownRawTiltRangeEndDegrees) {
                     if (lookingDownStartedAt == Long.MIN_VALUE) {
                         lookingDownStartedAt = timeProvider()
                     }
@@ -238,7 +250,7 @@ class CrossingSupportManager(
                     lookingDownStartedAt = Long.MIN_VALUE
                 }
 
-                if (signedTiltDegrees in config.lookingUpRawTiltRangeStartDegrees..config.lookingUpRawTiltRangeEndDegrees) {
+                if (signedTiltDegrees in lookingUpRawTiltRangeStartDegrees..lookingUpRawTiltRangeEndDegrees) {
                     if (lookingUpStartedAt == Long.MIN_VALUE) {
                         lookingUpStartedAt = timeProvider()
                     }

--- a/app/src/main/res/drawable/debug_spinner_outline_background.xml
+++ b/app/src/main/res/drawable/debug_spinner_outline_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/via_surface_scrim" />
+    <corners android:radius="14dp" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/via_surface_outline" />
+    <padding
+        android:left="12dp"
+        android:top="6dp"
+        android:right="12dp"
+        android:bottom="6dp" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,6 +14,14 @@
         android:layout_height="match_parent"
         android:contentDescription="실시간 카메라 미리보기" />
 
+    <ImageView
+        android:id="@+id/videoReplayFrameView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="샘플 영상 리플레이 프레임"
+        android:scaleType="centerCrop"
+        android:visibility="gone" />
+
     <View
         android:id="@+id/statusTintOverlay"
         android:layout_width="match_parent"
@@ -210,6 +218,18 @@
                     android:layout_marginTop="12dp"
                     android:minHeight="56dp"
                     android:text="앱 초기 상태로 되돌리기"
+                    android:textAllCaps="false"
+                    android:textSize="16sp"
+                    app:cornerRadius="18dp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/videoReplayButton"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:minHeight="56dp"
+                    android:text="샘플 영상 선택"
                     android:textAllCaps="false"
                     android:textSize="16sp"
                     app:cornerRadius="18dp" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,7 +14,7 @@
         android:layout_height="match_parent"
         android:contentDescription="실시간 카메라 미리보기" />
 
-    <VideoView
+    <TextureView
         android:id="@+id/videoReplayFrameView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -238,18 +238,37 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="14dp"
-                    android:text="Model: Loading..."
+                    android:text="현재 모델: Loading..."
                     android:textColor="@color/via_on_surface"
                     android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/modelSpinnerLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:text="테스트할 모델 선택"
+                    android:textColor="@color/via_accent"
+                    android:textSize="15sp"
                     android:textStyle="bold" />
 
                 <Spinner
                     android:id="@+id/modelSpinner"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="12dp"
+                    android:layout_marginTop="6dp"
                     android:backgroundTint="@color/via_accent_container"
                     android:importantForAccessibility="yes" />
+
+                <TextView
+                    android:id="@+id/modelSpinnerHint"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="눌러서 7cls_v2 해상도/INT8·float16 모델을 바꿔 테스트"
+                    android:textColor="@color/via_on_surface_variant"
+                    android:textSize="12sp" />
 
                 <TextView
                     android:id="@+id/inputFpsText"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -14,12 +14,11 @@
         android:layout_height="match_parent"
         android:contentDescription="실시간 카메라 미리보기" />
 
-    <ImageView
+    <VideoView
         android:id="@+id/videoReplayFrameView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:contentDescription="샘플 영상 리플레이 프레임"
-        android:scaleType="centerCrop"
         android:visibility="gone" />
 
     <View

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -256,19 +256,12 @@
                 <Spinner
                     android:id="@+id/modelSpinner"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="52dp"
                     android:layout_marginTop="6dp"
-                    android:backgroundTint="@color/via_accent_container"
+                    android:background="@drawable/debug_spinner_outline_background"
+                    android:minHeight="52dp"
+                    android:paddingHorizontal="12dp"
                     android:importantForAccessibility="yes" />
-
-                <TextView
-                    android:id="@+id/modelSpinnerHint"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:text="눌러서 7cls_v2 해상도/INT8·float16 모델을 바꿔 테스트"
-                    android:textColor="@color/via_on_surface_variant"
-                    android:textSize="12sp" />
 
                 <TextView
                     android:id="@+id/inputFpsText"
@@ -473,7 +466,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
-                    android:text="Down Tilt: 45°"
+                    android:text="Down Tilt Range: -160..-90"
                     android:textColor="@color/via_on_surface"
                     android:textSize="16sp"
                     android:textStyle="bold" />
@@ -482,9 +475,28 @@
                     android:id="@+id/downTiltSlider"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:value="45"
-                    android:valueFrom="20.0"
-                    android:valueTo="90.0"
+                    android:value="90"
+                    android:valueFrom="70.0"
+                    android:valueTo="140.0"
+                    android:stepSize="1.0" />
+
+                <TextView
+                    android:id="@+id/upTiltLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="Up Tilt Range: 90..120"
+                    android:textColor="@color/via_on_surface"
+                    android:textSize="16sp"
+                    android:textStyle="bold" />
+
+                <com.google.android.material.slider.Slider
+                    android:id="@+id/upTiltSlider"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:value="120"
+                    android:valueFrom="90.0"
+                    android:valueTo="170.0"
                     android:stepSize="1.0" />
             </LinearLayout>
         </ScrollView>


### PR DESCRIPTION
## 요약
- 디버그 패널에서 샘플 영상을 선택해 카메라 입력 대신 리플레이 프레임을 분석할 수 있게 추가
- TextureView/MediaPlayer 기반으로 실제 표시 중인 영상 프레임을 캡처해 기존 YOLO → SignalAnalyzer → advisory/overlay/debug 경로에 투입
- 리플레이 FPS, 2x replay zoom, replay overlay 좌표 보정 추가
- 모델 선택 UI 외곽선 정리 및 down/up tilt debug tuning 분리 복구

## 테스트
- `./gradlew.bat testDebugUnitTest lintDebug assembleDebug`
- `adb -s 192.168.75.83:44771 install -r .\app\build\outputs\apk\debug\app-debug.apk`
- `adb launch reached MainActivity`

Closes #30