### PR TITLE
Separate user settings from debug controls

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,10 @@
             android:exported="true"
             android:screenOrientation="portrait" />
         <activity
+            android:name=".settings.SettingsActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".DebugMapActivity"
             android:exported="false"
             android:screenOrientation="portrait" />

--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -62,6 +62,7 @@ import kr.co.gachon.pproject6.via.map.KineticGuestSessionManager
 import kr.co.gachon.pproject6.via.map.MapDebugCacheManager
 import kr.co.gachon.pproject6.via.onboarding.AppPreferences
 import kr.co.gachon.pproject6.via.onboarding.OnboardingActivity
+import kr.co.gachon.pproject6.via.settings.SettingsActivity
 import kr.co.gachon.pproject6.via.ui.OverlayView
 import kr.co.gachon.pproject6.via.util.ImageUtils
 import kr.co.gachon.pproject6.via.util.PerformanceTracker
@@ -127,6 +128,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var trafficLogicSwitch: androidx.appcompat.widget.SwitchCompat
     private lateinit var highlightTargetSwitch: androidx.appcompat.widget.SwitchCompat
     private lateinit var debugContainer: View
+    private lateinit var settingsButton: android.widget.ImageButton
     private lateinit var debugToggleButton: android.widget.ImageButton
     private lateinit var buildInfoCard: View
     private lateinit var topControlCard: View
@@ -236,6 +238,16 @@ class MainActivity : AppCompatActivity() {
             startVideoReplay(uri)
         }
 
+    private val settingsLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            applyUserFeedbackPreferences()
+            if (result.resultCode == RESULT_OK &&
+                result.data?.getBooleanExtra(SettingsActivity.EXTRA_OPEN_DEBUG_PANEL, false) == true
+            ) {
+                setDebugPanelVisible(true)
+            }
+        }
+
     // 7-class fine-tuned model labels. Only human_* labels drive pedestrian signal guidance.
     private val finetunedLabels = DetectionLabels.sevenClassLabels
 
@@ -271,6 +283,7 @@ class MainActivity : AppCompatActivity() {
         statusTintOverlay = findViewById(R.id.statusTintOverlay)
         overlay = findViewById(R.id.overlay)
         debugContainer = findViewById(R.id.debugContainer)
+        settingsButton = findViewById(R.id.settingsButton)
         debugToggleButton = findViewById(R.id.debugToggleButton)
         buildInfoCard = findViewById(R.id.buildInfoCard)
         topControlCard = findViewById(R.id.topControlCard)
@@ -310,23 +323,22 @@ class MainActivity : AppCompatActivity() {
         highlightTargetSwitch = findViewById(R.id.swHighlightTarget)
         statusBorder = findViewById(R.id.statusBorder)
         feedbackManager = SignalFeedbackManager(this)
+        applyUserFeedbackPreferences()
         crossingSupportManager = CrossingSupportManager(this, GuidanceTuningDefaults.crossingSupportConfig)
         buildInfoText.text = "v${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE}) · ${BuildConfig.BUILD_STAMP}"
         updateTuningDebugText()
         Log.i("VIA_GUIDANCE", "tuning=${GuidanceTuningDefaults.toDebugSummary()}")
         modelNameText.text = "모델: $currentModelName"
 
-        debugContainer.visibility =
-            if (showDebugInfo) View.VISIBLE else View.GONE
+        setDebugPanelVisible(showDebugInfo)
 
         applySystemBarInsets()
 
+        settingsButton.setOnClickListener {
+            settingsLauncher.launch(Intent(this, SettingsActivity::class.java))
+        }
         debugToggleButton.setOnClickListener {
-            showDebugInfo = !showDebugInfo
-            debugContainer.visibility =
-                if (showDebugInfo) View.VISIBLE else View.GONE
-            debugToggleButton.contentDescription =
-                if (showDebugInfo) "디버그 정보 닫기" else "디버그 정보 열기"
+            setDebugPanelVisible(!showDebugInfo)
         }
         videoReplayButton.setOnClickListener {
             if (videoReplayRunning.get()) {
@@ -446,6 +458,9 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
+        if (::feedbackManager.isInitialized) {
+            applyUserFeedbackPreferences()
+        }
         crossingSupportManager.start()
         latestCrossingSupportSnapshot = crossingSupportManager.snapshot()
         updateGpsDebugMapButtonState()
@@ -582,6 +597,18 @@ class MainActivity : AppCompatActivity() {
     private fun updateUpTiltLabel() {
         upTiltLabel.text =
             "Up Tilt Range: 90..${String.format(Locale.US, "%.0f", crossingSupportManager.currentLookingUpThresholdDegrees())}"
+    }
+
+    private fun setDebugPanelVisible(visible: Boolean) {
+        showDebugInfo = visible
+        debugContainer.visibility = if (visible) View.VISIBLE else View.GONE
+        debugToggleButton.contentDescription =
+            if (visible) "디버그 정보 닫기" else "디버그 정보 열기"
+    }
+
+    private fun applyUserFeedbackPreferences() {
+        feedbackManager.voiceEnabled = preferences.voiceGuidanceEnabled
+        feedbackManager.hapticEnabled = preferences.hapticFeedbackEnabled
     }
 
     private fun updateDebugInfo(
@@ -1479,8 +1506,10 @@ class MainActivity : AppCompatActivity() {
 
         val visualState = deriveStatusVisualState(analysisResult)
         statusBorder.setBackgroundResource(visualState.borderResId)
-        statusTintOverlay.setBackgroundColor(visualState.tintColor)
-        statusTintOverlay.alpha = if (visualState.tintColor == Color.TRANSPARENT) 0f else 1f
+        val tintColor =
+            if (preferences.screenColorFeedbackEnabled) visualState.tintColor else Color.TRANSPARENT
+        statusTintOverlay.setBackgroundColor(tintColor)
+        statusTintOverlay.alpha = if (tintColor == Color.TRANSPARENT) 0f else 1f
         statusIconText.text = visualState.iconText
         statusIconText.setTextColor(visualState.iconTextColor)
         statusIconText.backgroundTintList = ColorStateList.valueOf(visualState.iconBackgroundColor)

--- a/app/src/main/java/kr/co/gachon/pproject6/via/onboarding/AppPreferences.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/onboarding/AppPreferences.kt
@@ -41,6 +41,18 @@ class AppPreferences(context: Context) {
         get() = prefs.getString(KEY_MAP_INSTALLATION_ID, null)
         set(value) = prefs.edit().putString(KEY_MAP_INSTALLATION_ID, value).apply()
 
+    var voiceGuidanceEnabled: Boolean
+        get() = prefs.getBoolean(KEY_VOICE_GUIDANCE_ENABLED, true)
+        set(value) = prefs.edit().putBoolean(KEY_VOICE_GUIDANCE_ENABLED, value).apply()
+
+    var hapticFeedbackEnabled: Boolean
+        get() = prefs.getBoolean(KEY_HAPTIC_FEEDBACK_ENABLED, true)
+        set(value) = prefs.edit().putBoolean(KEY_HAPTIC_FEEDBACK_ENABLED, value).apply()
+
+    var screenColorFeedbackEnabled: Boolean
+        get() = prefs.getBoolean(KEY_SCREEN_COLOR_FEEDBACK_ENABLED, true)
+        set(value) = prefs.edit().putBoolean(KEY_SCREEN_COLOR_FEEDBACK_ENABLED, value).apply()
+
     fun saveCalibration(
         result: CalibrationProfileResult,
         deviceSummary: String,
@@ -78,5 +90,8 @@ class AppPreferences(context: Context) {
         private const val KEY_MAP_DATASET_VERSION = "map_dataset_version"
         private const val KEY_MAP_LAST_DATASET_CHECK_AT = "map_last_dataset_check_at"
         private const val KEY_MAP_INSTALLATION_ID = "map_installation_id"
+        private const val KEY_VOICE_GUIDANCE_ENABLED = "voice_guidance_enabled"
+        private const val KEY_HAPTIC_FEEDBACK_ENABLED = "haptic_feedback_enabled"
+        private const val KEY_SCREEN_COLOR_FEEDBACK_ENABLED = "screen_color_feedback_enabled"
     }
 }

--- a/app/src/main/java/kr/co/gachon/pproject6/via/settings/SettingsActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/settings/SettingsActivity.kt
@@ -1,0 +1,114 @@
+package kr.co.gachon.pproject6.via.settings
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.switchmaterial.SwitchMaterial
+import kr.co.gachon.pproject6.via.R
+import kr.co.gachon.pproject6.via.map.MapDebugCacheManager
+import kr.co.gachon.pproject6.via.onboarding.AppPreferences
+
+class SettingsActivity : AppCompatActivity() {
+    private lateinit var preferences: AppPreferences
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        preferences = AppPreferences(this)
+        setContentView(R.layout.activity_settings)
+
+        findViewById<MaterialButton>(R.id.settingsBackButton).setOnClickListener {
+            finish()
+        }
+
+        bindSwitch(
+            switch = findViewById(R.id.voiceGuidanceSwitch),
+            initialValue = preferences.voiceGuidanceEnabled,
+            onChanged = { preferences.voiceGuidanceEnabled = it }
+        )
+        bindSwitch(
+            switch = findViewById(R.id.hapticFeedbackSwitch),
+            initialValue = preferences.hapticFeedbackEnabled,
+            onChanged = { preferences.hapticFeedbackEnabled = it }
+        )
+        bindSwitch(
+            switch = findViewById(R.id.screenColorFeedbackSwitch),
+            initialValue = preferences.screenColorFeedbackEnabled,
+            onChanged = { preferences.screenColorFeedbackEnabled = it }
+        )
+
+        findViewById<MaterialButton>(R.id.contactSettingsButton).setOnClickListener {
+            showNextIssueToast("보호자 연락처 설정은 #34에서 연결됩니다.")
+        }
+        findViewById<MaterialButton>(R.id.bluetoothGuideButton).setOnClickListener {
+            showNextIssueToast("블루투스 버튼 안내/테스트는 #35에서 연결됩니다.")
+        }
+        findViewById<MaterialButton>(R.id.usageGuideButton).setOnClickListener {
+            showNextIssueToast("앱 사용 안내는 #38에서 정리됩니다.")
+        }
+        findViewById<MaterialButton>(R.id.openDebugPanelButton).setOnClickListener {
+            setResult(
+                Activity.RESULT_OK,
+                Intent().putExtra(EXTRA_OPEN_DEBUG_PANEL, true)
+            )
+            finish()
+        }
+        findViewById<MaterialButton>(R.id.clearMapCacheButton).setOnClickListener {
+            val deletedEntries = MapDebugCacheManager.clearAll(this)
+            Toast.makeText(this, "지도 캐시 ${deletedEntries}개를 삭제했습니다.", Toast.LENGTH_SHORT).show()
+        }
+
+        findViewById<TextView>(R.id.modelSummaryText).text =
+            buildString {
+                append("현재 AI 모델: ")
+                append(preferences.selectedModelName ?: "자동 선택 전")
+                preferences.selectedBackendLabel?.let { backend ->
+                    append("\n추론 방식: ")
+                    append(backend)
+                }
+            }
+        findViewById<TextView>(R.id.permissionStatusText).text = buildPermissionStatusText()
+    }
+
+    private fun bindSwitch(
+        switch: SwitchMaterial,
+        initialValue: Boolean,
+        onChanged: (Boolean) -> Unit
+    ) {
+        switch.isChecked = initialValue
+        switch.setOnCheckedChangeListener { _, isChecked ->
+            onChanged(isChecked)
+        }
+    }
+
+    private fun showNextIssueToast(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun buildPermissionStatusText(): String {
+        val camera = permissionSummary(Manifest.permission.CAMERA)
+        val fineLocation = permissionSummary(Manifest.permission.ACCESS_FINE_LOCATION)
+        val coarseLocation = permissionSummary(Manifest.permission.ACCESS_COARSE_LOCATION)
+        val location =
+            if (fineLocation == "허용" || coarseLocation == "허용") "허용" else "미허용"
+        return "권한 상태: 카메라 $camera · 위치 $location"
+    }
+
+    private fun permissionSummary(permission: String): String {
+        return if (ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED) {
+            "허용"
+        } else {
+            "미허용"
+        }
+    }
+
+    companion object {
+        const val EXTRA_OPEN_DEBUG_PANEL = "kr.co.gachon.pproject6.via.OPEN_DEBUG_PANEL"
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -83,15 +83,31 @@
         app:strokeColor="@color/via_surface_outline"
         app:strokeWidth="1dp">
 
-        <ImageButton
-            android:id="@+id/debugToggleButton"
-            android:layout_width="56dp"
-            android:layout_height="56dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="디버그 정보 열기"
-            android:padding="14dp"
-            android:src="@android:drawable/ic_menu_info_details"
-            app:tint="@color/via_on_surface" />
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <ImageButton
+                android:id="@+id/settingsButton"
+                android:layout_width="56dp"
+                android:layout_height="56dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="설정 열기"
+                android:padding="14dp"
+                android:src="@android:drawable/ic_menu_manage"
+                app:tint="@color/via_on_surface" />
+
+            <ImageButton
+                android:id="@+id/debugToggleButton"
+                android:layout_width="56dp"
+                android:layout_height="56dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="디버그 정보 열기"
+                android:padding="14dp"
+                android:src="@android:drawable/ic_menu_info_details"
+                app:tint="@color/via_on_surface" />
+        </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 
     <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/settingsRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/via_background"
+    android:fillViewport="true"
+    tools:context=".settings.SettingsActivity">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingHorizontal="20dp"
+        android:paddingTop="28dp"
+        android:paddingBottom="32dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/settingsBackButton"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="← 돌아가기"
+            android:textAllCaps="false"
+            android:textColor="@color/via_on_surface"
+            android:textSize="16sp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="설정"
+            android:textColor="@color/via_on_surface"
+            android:textSize="34sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:lineSpacingExtra="4dp"
+            android:text="일반 사용 설정과 테스트용 고급 설정을 분리했습니다."
+            android:textColor="@color/via_on_surface_variant"
+            android:textSize="16sp" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:cardBackgroundColor="@color/via_surface"
+            app:cardCornerRadius="24dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/via_surface_outline"
+            app:strokeWidth="1dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="20dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="일반 설정"
+                    android:textColor="@color/via_on_surface"
+                    android:textSize="22sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="최종 사용자가 직접 조정할 수 있는 항목입니다."
+                    android:textColor="@color/via_on_surface_variant"
+                    android:textSize="14sp" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/voiceGuidanceSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="18dp"
+                    android:minHeight="56dp"
+                    android:text="음성 안내"
+                    android:textColor="@color/via_on_surface"
+                    android:textSize="18sp" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/hapticFeedbackSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="56dp"
+                    android:text="진동 피드백"
+                    android:textColor="@color/via_on_surface"
+                    android:textSize="18sp" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/screenColorFeedbackSwitch"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="56dp"
+                    android:text="전체 화면 색상 피드백"
+                    android:textColor="@color/via_on_surface"
+                    android:textSize="18sp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/contactSettingsButton"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:minHeight="56dp"
+                    android:text="보호자/기관 연락처 설정"
+                    android:textAllCaps="false"
+                    android:textSize="16sp"
+                    app:cornerRadius="18dp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/bluetoothGuideButton"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:minHeight="56dp"
+                    android:text="블루투스 버튼 안내/테스트"
+                    android:textAllCaps="false"
+                    android:textSize="16sp"
+                    app:cornerRadius="18dp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/usageGuideButton"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:minHeight="56dp"
+                    android:text="앱 사용 안내"
+                    android:textAllCaps="false"
+                    android:textSize="16sp"
+                    app:cornerRadius="18dp" />
+
+                <TextView
+                    android:id="@+id/permissionStatusText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:lineSpacingExtra="4dp"
+                    android:textColor="@color/via_on_surface_variant"
+                    android:textSize="14sp"
+                    tools:text="권한 상태: 카메라 허용 · 위치 허용" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="18dp"
+            app:cardBackgroundColor="@color/via_surface"
+            app:cardCornerRadius="24dp"
+            app:cardElevation="0dp"
+            app:strokeColor="@color/via_surface_outline"
+            app:strokeWidth="1dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="20dp">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="고급 / 디버그 설정"
+                    android:textColor="@color/via_on_surface"
+                    android:textSize="22sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/advancedSummaryText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:lineSpacingExtra="4dp"
+                    android:text="AI 모델 선택, 샘플 영상 리플레이, FPS, 틸트 범위, GPS 매칭 정보는 메인 화면의 디버그 패널에서 확인합니다."
+                    android:textColor="@color/via_on_surface_variant"
+                    android:textSize="14sp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/openDebugPanelButton"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:minHeight="56dp"
+                    android:text="메인 디버그 패널 열기"
+                    android:textAllCaps="false"
+                    android:textSize="16sp"
+                    app:cornerRadius="18dp" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/clearMapCacheButton"
+                    style="@style/Widget.Material3.Button.OutlinedButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:minHeight="56dp"
+                    android:text="지도/OSM 캐시 초기화"
+                    android:textAllCaps="false"
+                    android:textSize="16sp"
+                    app:cornerRadius="18dp" />
+
+                <TextView
+                    android:id="@+id/modelSummaryText"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="14dp"
+                    android:lineSpacingExtra="4dp"
+                    android:textColor="@color/via_on_surface_variant"
+                    android:textSize="14sp"
+                    tools:text="현재 AI 모델: best_7cls_v2_float16_320.tflite" />
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## Summary
- Add a dedicated Settings screen with separated General and Advanced/Debug sections.
- Persist user-facing feedback toggles for voice guidance, haptic feedback, and full-screen color feedback.
- Add a main-screen settings entry point while keeping the existing debug panel reachable from Advanced/Debug settings.
- Surface current model/backend, permission status, and map cache clearing in the settings flow.

## Verification
- `./gradlew.bat testDebugUnitTest`
- `./gradlew.bat lintDebug`
- `./gradlew.bat assembleDebug`

Closes #37