### PR TITLE
Let users stage emergency contact requests safely

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,11 +5,15 @@
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.SEND_SMS" />
 
     <application
         android:name=".ViaApplication"
@@ -38,6 +42,10 @@
             android:screenOrientation="portrait" />
         <activity
             android:name=".settings.SettingsActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
+            android:name=".safety.EmergencyContactActivity"
             android:exported="false"
             android:screenOrientation="portrait" />
         <activity

--- a/app/src/main/java/kr/co/gachon/pproject6/via/onboarding/AppPreferences.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/onboarding/AppPreferences.kt
@@ -53,6 +53,21 @@ class AppPreferences(context: Context) {
         get() = prefs.getBoolean(KEY_SCREEN_COLOR_FEEDBACK_ENABLED, true)
         set(value) = prefs.edit().putBoolean(KEY_SCREEN_COLOR_FEEDBACK_ENABLED, value).apply()
 
+    var emergencyContactName: String?
+        get() = prefs.getString(KEY_EMERGENCY_CONTACT_NAME, null)
+        set(value) = prefs.edit().putString(KEY_EMERGENCY_CONTACT_NAME, value).apply()
+
+    var emergencyContactPhone: String?
+        get() = prefs.getString(KEY_EMERGENCY_CONTACT_PHONE, null)
+        set(value) = prefs.edit().putString(KEY_EMERGENCY_CONTACT_PHONE, value).apply()
+
+    fun clearEmergencyContact() {
+        prefs.edit()
+            .remove(KEY_EMERGENCY_CONTACT_NAME)
+            .remove(KEY_EMERGENCY_CONTACT_PHONE)
+            .apply()
+    }
+
     fun saveCalibration(
         result: CalibrationProfileResult,
         deviceSummary: String,
@@ -93,5 +108,7 @@ class AppPreferences(context: Context) {
         private const val KEY_VOICE_GUIDANCE_ENABLED = "voice_guidance_enabled"
         private const val KEY_HAPTIC_FEEDBACK_ENABLED = "haptic_feedback_enabled"
         private const val KEY_SCREEN_COLOR_FEEDBACK_ENABLED = "screen_color_feedback_enabled"
+        private const val KEY_EMERGENCY_CONTACT_NAME = "emergency_contact_name"
+        private const val KEY_EMERGENCY_CONTACT_PHONE = "emergency_contact_phone"
     }
 }

--- a/app/src/main/java/kr/co/gachon/pproject6/via/safety/EmergencyContactActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/safety/EmergencyContactActivity.kt
@@ -1,0 +1,420 @@
+package kr.co.gachon.pproject6.via.safety
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationManager
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.os.CountDownTimer
+import android.telephony.SmsManager
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
+import kr.co.gachon.pproject6.via.R
+import kr.co.gachon.pproject6.via.onboarding.AppPreferences
+
+class EmergencyContactActivity : AppCompatActivity() {
+    private lateinit var preferences: AppPreferences
+    private lateinit var contactNameInput: EditText
+    private lateinit var contactPhoneInput: EditText
+    private lateinit var statusText: TextView
+    private lateinit var sendButton: MaterialButton
+    private lateinit var cancelButton: MaterialButton
+    private var countdownTimer: CountDownTimer? = null
+
+    private val requestSmsPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                startEmergencyCountdown()
+            } else {
+                Toast.makeText(this, "SMS 권한이 없어 문자 앱을 엽니다.", Toast.LENGTH_LONG).show()
+                openSmsApp()
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        preferences = AppPreferences(this)
+        val views = createContentView()
+        setContentView(views.root)
+
+        contactNameInput = views.contactNameInput
+        contactPhoneInput = views.contactPhoneInput
+        statusText = views.statusText
+        sendButton = views.sendButton
+        cancelButton = views.cancelButton
+
+        contactNameInput.setText(preferences.emergencyContactName.orEmpty())
+        contactPhoneInput.setText(preferences.emergencyContactPhone.orEmpty())
+        updateStatus()
+
+        views.backButton.setOnClickListener { finish() }
+        views.saveButton.setOnClickListener {
+            saveContact()
+        }
+        views.deleteButton.setOnClickListener {
+            preferences.clearEmergencyContact()
+            contactNameInput.text.clear()
+            contactPhoneInput.text.clear()
+            cancelEmergencyCountdown()
+            updateStatus()
+            Toast.makeText(this, "비상 연락처를 삭제했습니다.", Toast.LENGTH_SHORT).show()
+        }
+        sendButton.setOnClickListener {
+            if (!ensureContactSaved()) return@setOnClickListener
+            if (hasSmsPermission()) {
+                startEmergencyCountdown()
+            } else {
+                requestSmsPermissionLauncher.launch(Manifest.permission.SEND_SMS)
+            }
+        }
+        cancelButton.setOnClickListener {
+            cancelEmergencyCountdown()
+            statusText.text = "비상 문자 발송을 취소했습니다."
+        }
+        views.openSmsAppButton.setOnClickListener {
+            if (ensureContactSaved()) {
+                openSmsApp()
+            }
+        }
+    }
+
+    override fun onStop() {
+        cancelEmergencyCountdown()
+        super.onStop()
+    }
+
+    private fun saveContact(): Boolean {
+        val name = contactNameInput.text?.toString()?.trim().orEmpty()
+        val phone = contactPhoneInput.text?.toString()?.trim().orEmpty()
+        if (phone.isBlank()) {
+            contactPhoneInput.error = "전화번호를 입력해 주세요"
+            return false
+        }
+
+        preferences.emergencyContactName = name.ifBlank { "비상 연락처" }
+        preferences.emergencyContactPhone = phone
+        updateStatus()
+        Toast.makeText(this, "비상 연락처를 저장했습니다.", Toast.LENGTH_SHORT).show()
+        return true
+    }
+
+    private fun ensureContactSaved(): Boolean {
+        val typedPhone = contactPhoneInput.text?.toString()?.trim().orEmpty()
+        val savedPhone = preferences.emergencyContactPhone.orEmpty()
+        return if (typedPhone.isNotBlank() && typedPhone != savedPhone) {
+            saveContact()
+        } else if (savedPhone.isBlank()) {
+            statusText.text = "비상 연락처를 먼저 저장해 주세요."
+            false
+        } else {
+            true
+        }
+    }
+
+    private fun startEmergencyCountdown() {
+        val phone = preferences.emergencyContactPhone
+        if (phone.isNullOrBlank()) {
+            statusText.text = "비상 연락처를 먼저 저장해 주세요."
+            return
+        }
+
+        cancelEmergencyCountdown()
+        sendButton.isEnabled = false
+        cancelButton.visibility = View.VISIBLE
+        countdownTimer = object : CountDownTimer(AUTO_SEND_DELAY_MS, 1_000L) {
+            override fun onTick(millisUntilFinished: Long) {
+                val seconds = ((millisUntilFinished + 999L) / 1_000L).coerceAtLeast(1L)
+                statusText.text = "${seconds}초 후 보호자에게 비상 문자를 보냅니다. 취소할 수 있습니다."
+            }
+
+            override fun onFinish() {
+                countdownTimer = null
+                cancelButton.visibility = View.GONE
+                sendButton.isEnabled = true
+                sendEmergencySms(phone)
+            }
+        }.start()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun sendEmergencySms(phone: String) {
+        if (!hasSmsPermission()) {
+            openSmsApp()
+            return
+        }
+
+        val message = buildEmergencyMessage()
+        runCatching {
+            val smsManager =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    getSystemService(SmsManager::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    SmsManager.getDefault()
+                }
+            val parts = smsManager.divideMessage(message)
+            smsManager.sendMultipartTextMessage(phone, null, parts, null, null)
+        }.onSuccess {
+            statusText.text = "비상 문자를 발송했습니다."
+            Toast.makeText(this, "비상 문자를 발송했습니다.", Toast.LENGTH_LONG).show()
+        }.onFailure {
+            statusText.text = "자동 발송에 실패해 문자 앱을 엽니다."
+            Toast.makeText(this, "자동 발송 실패: 문자 앱을 엽니다.", Toast.LENGTH_LONG).show()
+            openSmsApp()
+        }
+    }
+
+    private fun openSmsApp() {
+        val phone = preferences.emergencyContactPhone
+        if (phone.isNullOrBlank()) {
+            statusText.text = "비상 연락처를 먼저 저장해 주세요."
+            return
+        }
+
+        val intent = Intent(Intent.ACTION_SENDTO, Uri.parse("smsto:$phone")).apply {
+            putExtra("sms_body", buildEmergencyMessage())
+        }
+        runCatching {
+            startActivity(intent)
+        }.onFailure {
+            Toast.makeText(this, "문자 앱을 열 수 없습니다.", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun cancelEmergencyCountdown() {
+        countdownTimer?.cancel()
+        countdownTimer = null
+        cancelButton.visibility = View.GONE
+        sendButton.isEnabled = true
+    }
+
+    private fun updateStatus() {
+        val name = preferences.emergencyContactName
+        val phone = preferences.emergencyContactPhone
+        statusText.text =
+            if (phone.isNullOrBlank()) {
+                "연락처를 저장하면 비상 문자 기능을 사용할 수 있습니다."
+            } else {
+                "등록된 연락처: ${name ?: "비상 연락처"} · $phone"
+            }
+    }
+
+    private fun buildEmergencyMessage(): String {
+        return EmergencyMessageBuilder.build(readLastKnownEmergencyLocation())
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun readLastKnownEmergencyLocation(): EmergencyLocation? {
+        if (!hasLocationPermission()) {
+            return null
+        }
+        val locationManager = getSystemService(LocationManager::class.java) ?: return null
+        val location =
+            listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+                .mapNotNull { provider ->
+                    runCatching { locationManager.getLastKnownLocation(provider) }.getOrNull()
+                }
+                .maxByOrNull(Location::getTime)
+                ?: return null
+        return EmergencyLocation(location.latitude, location.longitude)
+    }
+
+    private fun hasSmsPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(this, Manifest.permission.SEND_SMS) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun hasLocationPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun createContentView(): EmergencyContactViews {
+        val root = ScrollView(this).apply {
+            setBackgroundColor(ContextCompat.getColor(this@EmergencyContactActivity, R.color.via_background))
+            isFillViewport = true
+        }
+        val content = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20), dp(28), dp(20), dp(32))
+        }
+        root.addView(content, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+
+        val backButton = textButton("← 설정으로 돌아가기")
+        content.addView(backButton, matchWrap())
+        content.addView(titleText("비상 연락"), matchWrap(topMargin = 8))
+        content.addView(
+            bodyText("보호자 또는 기관 연락처를 저장하고, 필요할 때 5초 유예 후 비상 문자를 보냅니다."),
+            matchWrap(topMargin = 8)
+        )
+
+        val contactNameInput = editText("이름 또는 기관명").apply {
+            inputType = android.text.InputType.TYPE_CLASS_TEXT or
+                android.text.InputType.TYPE_TEXT_VARIATION_PERSON_NAME
+        }
+        val contactPhoneInput = editText("전화번호").apply {
+            inputType = android.text.InputType.TYPE_CLASS_PHONE
+        }
+        val saveButton = filledButton("연락처 저장")
+        val deleteButton = outlinedButton("연락처 삭제")
+        content.addView(
+            card {
+                addView(contactNameInput, matchWrap())
+                addView(contactPhoneInput, matchWrap(topMargin = 12))
+                addView(saveButton, matchWrap(topMargin = 18))
+                addView(deleteButton, matchWrap(topMargin = 10))
+            },
+            matchWrap(topMargin = 24)
+        )
+
+        val statusText = bodyText("연락처를 저장하면 비상 문자 기능을 사용할 수 있습니다.")
+        val sendButton = filledButton("비상 문자 자동 발송").apply {
+            minHeight = dp(64)
+            textSize = 18f
+        }
+        val cancelButton = outlinedButton("발송 취소").apply {
+            visibility = View.GONE
+        }
+        val openSmsAppButton = outlinedButton("문자 앱에서 직접 작성")
+        content.addView(
+            card {
+                addView(statusText, matchWrap())
+                addView(sendButton, matchWrap(topMargin = 16))
+                addView(cancelButton, matchWrap(topMargin = 10))
+                addView(openSmsAppButton, matchWrap(topMargin = 10))
+            },
+            matchWrap(topMargin = 18)
+        )
+
+        return EmergencyContactViews(
+            root = root,
+            backButton = backButton,
+            contactNameInput = contactNameInput,
+            contactPhoneInput = contactPhoneInput,
+            saveButton = saveButton,
+            deleteButton = deleteButton,
+            statusText = statusText,
+            sendButton = sendButton,
+            cancelButton = cancelButton,
+            openSmsAppButton = openSmsAppButton
+        )
+    }
+
+    private fun card(contentBuilder: LinearLayout.() -> Unit): MaterialCardView {
+        val cardContent = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20), dp(20), dp(20), dp(20))
+            contentBuilder()
+        }
+        return MaterialCardView(this).apply {
+            radius = dp(24).toFloat()
+            cardElevation = 0f
+            setCardBackgroundColor(ContextCompat.getColor(this@EmergencyContactActivity, R.color.via_surface))
+            strokeColor = ContextCompat.getColor(this@EmergencyContactActivity, R.color.via_surface_outline)
+            strokeWidth = dp(1)
+            addView(cardContent, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        }
+    }
+
+    private fun titleText(text: String): TextView =
+        TextView(this).apply {
+            this.text = text
+            setTextColor(ContextCompat.getColor(this@EmergencyContactActivity, R.color.via_on_surface))
+            textSize = 34f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+        }
+
+    private fun bodyText(text: String): TextView =
+        TextView(this).apply {
+            this.text = text
+            setTextColor(ContextCompat.getColor(this@EmergencyContactActivity, R.color.via_on_surface_variant))
+            textSize = 16f
+            setLineSpacing(dp(4).toFloat(), 1f)
+        }
+
+    private fun editText(hintText: String): EditText =
+        EditText(this).apply {
+            hint = hintText
+            minHeight = dp(56)
+            setTextColor(ContextCompat.getColor(this@EmergencyContactActivity, R.color.via_on_surface))
+            setHintTextColor(ContextCompat.getColor(this@EmergencyContactActivity, R.color.via_on_surface_variant))
+            textSize = 18f
+        }
+
+    private fun filledButton(text: String): MaterialButton =
+        MaterialButton(this).apply {
+            this.text = text
+            isAllCaps = false
+            textSize = 16f
+            minHeight = dp(56)
+            cornerRadius = dp(18)
+            gravity = Gravity.CENTER
+        }
+
+    private fun outlinedButton(text: String): MaterialButton =
+        MaterialButton(this, null, com.google.android.material.R.attr.materialButtonOutlinedStyle).apply {
+            this.text = text
+            isAllCaps = false
+            textSize = 16f
+            minHeight = dp(56)
+            cornerRadius = dp(18)
+            gravity = Gravity.CENTER
+        }
+
+    private fun textButton(text: String): MaterialButton =
+        MaterialButton(this, null, com.google.android.material.R.attr.borderlessButtonStyle).apply {
+            this.text = text
+            isAllCaps = false
+            textSize = 16f
+            minHeight = dp(48)
+            setTextColor(ContextCompat.getColor(this@EmergencyContactActivity, R.color.via_on_surface))
+            gravity = Gravity.CENTER_VERTICAL
+        }
+
+    private fun matchWrap(topMargin: Int = 0): LinearLayout.LayoutParams =
+        LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ).apply {
+            if (topMargin > 0) {
+                setMargins(0, dp(topMargin), 0, 0)
+            }
+        }
+
+    private fun dp(value: Int): Int =
+        (value * resources.displayMetrics.density).toInt()
+
+    private companion object {
+        private const val AUTO_SEND_DELAY_MS = 5_000L
+    }
+}
+
+private data class EmergencyContactViews(
+    val root: View,
+    val backButton: MaterialButton,
+    val contactNameInput: EditText,
+    val contactPhoneInput: EditText,
+    val saveButton: MaterialButton,
+    val deleteButton: MaterialButton,
+    val statusText: TextView,
+    val sendButton: MaterialButton,
+    val cancelButton: MaterialButton,
+    val openSmsAppButton: MaterialButton
+)

--- a/app/src/main/java/kr/co/gachon/pproject6/via/safety/EmergencyMessageBuilder.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/safety/EmergencyMessageBuilder.kt
@@ -1,0 +1,28 @@
+package kr.co.gachon.pproject6.via.safety
+
+import java.util.Locale
+
+object EmergencyMessageBuilder {
+    fun build(location: EmergencyLocation?): String {
+        val locationText =
+            if (location != null) {
+                "https://maps.google.com/?q=${formatCoordinate(location.latitude)},${formatCoordinate(location.longitude)}"
+            } else {
+                "현재 위치 확인 불가"
+            }
+        return """
+            현재 도움이 필요합니다.
+            VIA 앱에서 비상 연락 요청이 발생했습니다.
+            현재 위치: $locationText
+        """.trimIndent()
+    }
+
+    private fun formatCoordinate(value: Double): String {
+        return String.format(Locale.US, "%.6f", value)
+    }
+}
+
+data class EmergencyLocation(
+    val latitude: Double,
+    val longitude: Double
+)

--- a/app/src/main/java/kr/co/gachon/pproject6/via/settings/SettingsActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/settings/SettingsActivity.kt
@@ -14,6 +14,7 @@ import com.google.android.material.switchmaterial.SwitchMaterial
 import kr.co.gachon.pproject6.via.R
 import kr.co.gachon.pproject6.via.map.MapDebugCacheManager
 import kr.co.gachon.pproject6.via.onboarding.AppPreferences
+import kr.co.gachon.pproject6.via.safety.EmergencyContactActivity
 
 class SettingsActivity : AppCompatActivity() {
     private lateinit var preferences: AppPreferences
@@ -44,7 +45,7 @@ class SettingsActivity : AppCompatActivity() {
         )
 
         findViewById<MaterialButton>(R.id.contactSettingsButton).setOnClickListener {
-            showNextIssueToast("보호자 연락처 설정은 #34에서 연결됩니다.")
+            startActivity(Intent(this, EmergencyContactActivity::class.java))
         }
         findViewById<MaterialButton>(R.id.bluetoothGuideButton).setOnClickListener {
             showNextIssueToast("블루투스 버튼 안내/테스트는 #35에서 연결됩니다.")

--- a/app/src/test/java/kr/co/gachon/pproject6/via/safety/EmergencyMessageBuilderTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/safety/EmergencyMessageBuilderTest.kt
@@ -1,0 +1,23 @@
+package kr.co.gachon.pproject6.via.safety
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EmergencyMessageBuilderTest {
+    @Test
+    fun includesGoogleMapsLinkWhenLocationExists() {
+        val message = EmergencyMessageBuilder.build(
+            EmergencyLocation(latitude = 37.20313, longitude = 127.114663)
+        )
+
+        assertTrue(message.contains("현재 도움이 필요합니다."))
+        assertTrue(message.contains("https://maps.google.com/?q=37.203130,127.114663"))
+    }
+
+    @Test
+    fun fallsBackWhenLocationIsUnavailable() {
+        val message = EmergencyMessageBuilder.build(location = null)
+
+        assertTrue(message.contains("현재 위치 확인 불가"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add emergency contact storage through the Settings flow.
- Add a 5-second cancellable countdown before automatic SMS sending.
- Add a separate SMS app fallback/direct compose path with the same prefilled emergency message.
- Include last known location as a Google Maps link when available, otherwise fall back to a safe unavailable-location message.
- Add SEND_SMS permission with telephony marked optional and unit coverage for emergency message generation.

## Verification
- `./gradlew.bat testDebugUnitTest`
- `./gradlew.bat lintDebug`
- `./gradlew.bat assembleDebug`

Closes #34