### PR TITLE
Guide users to nearby crosswalk direction

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -20,6 +20,7 @@ import android.view.Surface
 import android.view.TextureView
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -36,6 +37,7 @@ import java.util.concurrent.Executors
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.content.ContextCompat
+import kr.co.gachon.pproject6.via.context.CrosswalkGuidanceMessageBuilder
 import kr.co.gachon.pproject6.via.feedback.SignalFeedbackManager
 import kr.co.gachon.pproject6.via.camera.CameraManager
 import kr.co.gachon.pproject6.via.context.CrossingSupportManager
@@ -306,6 +308,7 @@ class MainActivity : AppCompatActivity() {
         tuningDebugText = findViewById(R.id.tuningDebugText)
         statusTitleText = findViewById(R.id.statusTitleText)
         statusDetailText = findViewById(R.id.statusDetailText)
+        addNearbyCrosswalkGuideButton()
         statusIconText = findViewById(R.id.statusIconText)
         statusBadgeText = findViewById(R.id.statusBadgeText)
         confidenceSliderLabel = findViewById(R.id.confidenceSliderLabel)
@@ -454,6 +457,34 @@ class MainActivity : AppCompatActivity() {
         }
 
         setupModelSpinner()
+    }
+
+    private fun addNearbyCrosswalkGuideButton(): MaterialButton {
+        val statusContent =
+            (statusPanel as? ViewGroup)?.getChildAt(0) as? LinearLayout
+                ?: error("statusPanel content must be a LinearLayout")
+        return MaterialButton(this).apply {
+            text = "주변 횡단보도 안내"
+            isAllCaps = false
+            textSize = 17f
+            minHeight = dp(56)
+            cornerRadius = dp(18)
+            layoutParams =
+                LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply {
+                    topMargin = dp(16)
+                }
+            setOnClickListener {
+                announceNearbyCrosswalk()
+            }
+            statusContent.addView(this)
+        }
+    }
+
+    private fun dp(value: Int): Int {
+        return (value * resources.displayMetrics.density).toInt()
     }
 
     override fun onResume() {
@@ -1409,6 +1440,40 @@ class MainActivity : AppCompatActivity() {
                 mapVersion = mapSnapshot.datasetVersion,
                 isNearKnownFeature = mapSnapshot.isNearKnownFeature
             )
+        )
+    }
+
+    private fun announceNearbyCrosswalk() {
+        val guidanceMessage =
+            if (!hasAnyLocationPermission()) {
+                CrosswalkGuidanceMessageBuilder.build(CrossingSupportSnapshot())
+            } else {
+                CrosswalkGuidanceMessageBuilder.build(crosswalkGuidanceSnapshot())
+            }
+        Toast.makeText(this, guidanceMessage.detail, Toast.LENGTH_LONG).show()
+        feedbackManager.speakImmediate(
+            message = guidanceMessage.speechText,
+            utteranceId = "nearby_crosswalk_guidance"
+        )
+    }
+
+    private fun crosswalkGuidanceSnapshot(): CrossingSupportSnapshot {
+        val currentSnapshot = currentCrossingSupportSnapshot()
+        if (currentSnapshot.currentLocationLatitude != null &&
+            currentSnapshot.currentLocationLongitude != null
+        ) {
+            return currentSnapshot
+        }
+
+        val fallbackLocation = bestAvailableLocation() ?: return currentSnapshot
+        return currentSnapshot.copy(
+            currentLocationLatitude = fallbackLocation.latitude,
+            currentLocationLongitude = fallbackLocation.longitude,
+            currentLocationAccuracyMeters =
+                if (fallbackLocation.hasAccuracy()) fallbackLocation.accuracy else null,
+            currentHeadingDegrees =
+                currentSnapshot.currentHeadingDegrees
+                    ?: if (fallbackLocation.hasBearing()) fallbackLocation.bearing else null
         )
     }
 

--- a/app/src/main/java/kr/co/gachon/pproject6/via/context/CrossingSupportManager.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/context/CrossingSupportManager.kt
@@ -203,7 +203,8 @@ class CrossingSupportManager(
             currentLocationLatitude = lastLocationSample?.latitude,
             currentLocationLongitude = lastLocationSample?.longitude,
             currentLocationAccuracyMeters =
-                if (lastLocationSample?.hasAccuracy() == true) lastLocationSample?.accuracy else null
+                if (lastLocationSample?.hasAccuracy() == true) lastLocationSample?.accuracy else null,
+            currentHeadingDegrees = lastHeadingDegrees
         )
     }
 
@@ -391,7 +392,8 @@ data class CrossingSupportSnapshot(
     val mapProximitySnapshot: MapProximitySnapshot = MapProximitySnapshot(),
     val currentLocationLatitude: Double? = null,
     val currentLocationLongitude: Double? = null,
-    val currentLocationAccuracyMeters: Float? = null
+    val currentLocationAccuracyMeters: Float? = null,
+    val currentHeadingDegrees: Float? = null
 ) {
     val supportsWalkContinuation: Boolean
         get() = hasRecentGyroMotion || hasRecentLocationMovement || isLookingDown
@@ -400,6 +402,7 @@ data class CrossingSupportSnapshot(
         val latSummary = currentLocationLatitude?.let { String.format(Locale.US, "%.6f", it) } ?: "n/a"
         val lonSummary = currentLocationLongitude?.let { String.format(Locale.US, "%.6f", it) } ?: "n/a"
         val accSummary = currentLocationAccuracyMeters?.let { String.format(Locale.US, "%.1f", it) } ?: "n/a"
-        return "motion=$hasRecentGyroMotion, down=$isLookingDown, up=$isLookingUp, tilt=${String.format(Locale.US, "%.0f", currentTiltDegrees)}, signedTilt=${String.format(Locale.US, "%.0f", currentSignedTiltDegrees)}, gps=$hasRecentLocationMovement, keep=$supportsWalkContinuation, window=$isCrossingWindowActive, dist=${String.format(Locale.US, "%.1f", crossingWindowDistanceMeters)}, elapsed=${crossingWindowElapsedMs}ms, lat=$latSummary, lon=$lonSummary, acc=${accSummary}m, ${mapProximitySnapshot.toDebugSummary()}"
+        val headingSummary = currentHeadingDegrees?.let { String.format(Locale.US, "%.0f", it) } ?: "n/a"
+        return "motion=$hasRecentGyroMotion, down=$isLookingDown, up=$isLookingUp, tilt=${String.format(Locale.US, "%.0f", currentTiltDegrees)}, signedTilt=${String.format(Locale.US, "%.0f", currentSignedTiltDegrees)}, gps=$hasRecentLocationMovement, keep=$supportsWalkContinuation, window=$isCrossingWindowActive, dist=${String.format(Locale.US, "%.1f", crossingWindowDistanceMeters)}, elapsed=${crossingWindowElapsedMs}ms, lat=$latSummary, lon=$lonSummary, acc=${accSummary}m, heading=$headingSummary, ${mapProximitySnapshot.toDebugSummary()}"
     }
 }

--- a/app/src/main/java/kr/co/gachon/pproject6/via/context/CrosswalkGuidanceMessageBuilder.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/context/CrosswalkGuidanceMessageBuilder.kt
@@ -1,0 +1,127 @@
+package kr.co.gachon.pproject6.via.context
+
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+data class CrosswalkGuidanceMessage(
+    val title: String,
+    val detail: String,
+    val speechText: String
+)
+
+object CrosswalkGuidanceMessageBuilder {
+    private const val UNRELIABLE_LOCATION_ACCURACY_METERS = 35f
+    private const val DEFAULT_TITLE = "주변 횡단보도 안내"
+
+    fun build(snapshot: CrossingSupportSnapshot): CrosswalkGuidanceMessage {
+        val currentLatitude = snapshot.currentLocationLatitude
+        val currentLongitude = snapshot.currentLocationLongitude
+        if (currentLatitude == null || currentLongitude == null) {
+            return unavailable("현재 위치를 확인하지 못했습니다. 위치 권한과 GPS 상태를 확인해 주세요.")
+        }
+
+        val mapSnapshot = snapshot.mapProximitySnapshot
+        val matchedLatitude = mapSnapshot.matchedLatitude
+        val matchedLongitude = mapSnapshot.matchedLongitude
+        if (matchedLatitude == null || matchedLongitude == null) {
+            return unavailable("주변에서 확인된 횡단보도 정보가 없습니다. 잠시 이동한 뒤 다시 시도해 주세요.")
+        }
+
+        val distanceMeters =
+            mapSnapshot.distanceMeters
+                ?: haversineDistanceMeters(
+                    GeoPoint(currentLatitude, currentLongitude),
+                    GeoPoint(matchedLatitude, matchedLongitude)
+                )
+        val distanceText = formatDistanceMeters(distanceMeters)
+        val hasUnreliableLocation =
+            snapshot.currentLocationAccuracyMeters != null &&
+                snapshot.currentLocationAccuracyMeters > UNRELIABLE_LOCATION_ACCURACY_METERS
+        val headingDegrees = snapshot.currentHeadingDegrees.takeUnless { hasUnreliableLocation }
+
+        val detail =
+            if (headingDegrees != null) {
+                val bearingToCrosswalk =
+                    bearingDegrees(
+                        from = GeoPoint(currentLatitude, currentLongitude),
+                        to = GeoPoint(matchedLatitude, matchedLongitude)
+                    )
+                val direction = relativeDirectionLabel(
+                    targetBearingDegrees = bearingToCrosswalk,
+                    headingDegrees = headingDegrees
+                )
+                "가까운 횡단보도는 약 ${distanceText} ${directionSuffix(direction)} 있습니다."
+            } else {
+                val reason =
+                    if (hasUnreliableLocation) {
+                        "현재 위치 정확도가 낮아 방향 안내는 생략합니다."
+                    } else {
+                        "이동 방향을 아직 확인하지 못해 방향 안내는 생략합니다."
+                    }
+                "가까운 횡단보도는 약 ${distanceText} 거리에 있습니다. $reason"
+            }
+
+        return CrosswalkGuidanceMessage(
+            title = DEFAULT_TITLE,
+            detail = detail,
+            speechText = detail
+        )
+    }
+
+    private fun unavailable(detail: String): CrosswalkGuidanceMessage {
+        return CrosswalkGuidanceMessage(
+            title = DEFAULT_TITLE,
+            detail = detail,
+            speechText = detail
+        )
+    }
+
+    private fun formatDistanceMeters(distanceMeters: Float): String {
+        val roundedMeters =
+            when {
+                distanceMeters < 10f -> distanceMeters.roundToInt()
+                distanceMeters < 100f -> (distanceMeters / 5f).roundToInt() * 5
+                else -> (distanceMeters / 10f).roundToInt() * 10
+            }.coerceAtLeast(1)
+        return "${roundedMeters}미터"
+    }
+
+    private fun bearingDegrees(from: GeoPoint, to: GeoPoint): Float {
+        val fromLatitudeRadians = Math.toRadians(from.latitude)
+        val toLatitudeRadians = Math.toRadians(to.latitude)
+        val longitudeDeltaRadians = Math.toRadians(to.longitude - from.longitude)
+        val y = sin(longitudeDeltaRadians) * cos(toLatitudeRadians)
+        val x =
+            cos(fromLatitudeRadians) * sin(toLatitudeRadians) -
+                sin(fromLatitudeRadians) * cos(toLatitudeRadians) * cos(longitudeDeltaRadians)
+        return normalizeBearingDegrees(Math.toDegrees(atan2(y, x)).toFloat())
+    }
+
+    private fun relativeDirectionLabel(
+        targetBearingDegrees: Float,
+        headingDegrees: Float
+    ): String {
+        val delta =
+            ((normalizeBearingDegrees(targetBearingDegrees) -
+                normalizeBearingDegrees(headingDegrees) + 540f) % 360f) - 180f
+        val absDelta = kotlin.math.abs(delta)
+        val side = if (delta >= 0f) "오른쪽" else "왼쪽"
+        return when {
+            absDelta <= 22.5f -> "전방"
+            absDelta <= 67.5f -> "전방 $side"
+            absDelta <= 112.5f -> side
+            absDelta <= 157.5f -> "후방 $side"
+            else -> "뒤쪽"
+        }
+    }
+
+    private fun directionSuffix(direction: String): String {
+        return if (direction == "전방" || direction == "뒤쪽") {
+            "${direction}에"
+        } else {
+            "${direction} 방향에"
+        }
+    }
+}

--- a/app/src/main/java/kr/co/gachon/pproject6/via/feedback/SignalFeedbackManager.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/feedback/SignalFeedbackManager.kt
@@ -85,17 +85,21 @@ class SignalFeedbackManager(context: Context) : TextToSpeech.OnInitListener {
         cancelVibration()
     }
 
+    fun speakImmediate(message: String, utteranceId: String = "manual_guidance") {
+        speak(message, utteranceId)
+    }
+
     fun release() {
         clearState()
         tts.shutdown()
     }
 
-    private fun speak(message: String) {
+    private fun speak(message: String, utteranceId: String = "traffic_light_state") {
         if (!voiceEnabled || !ttsReady) {
             return
         }
 
-        tts.speak(message, TextToSpeech.QUEUE_FLUSH, null, "traffic_light_state")
+        tts.speak(message, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
     }
 
     private fun vibrate(pattern: LongArray) {

--- a/app/src/test/java/kr/co/gachon/pproject6/via/context/CrossingSupportSnapshotTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/context/CrossingSupportSnapshotTest.kt
@@ -94,7 +94,8 @@ class CrossingSupportSnapshotTest {
             currentSignedTiltDegrees = 32f,
             currentLocationLatitude = 37.450123,
             currentLocationLongitude = 127.128456,
-            currentLocationAccuracyMeters = 5.5f
+            currentLocationAccuracyMeters = 5.5f,
+            currentHeadingDegrees = 182f
         )
 
         val summary = snapshot.toDebugSummary()
@@ -104,5 +105,6 @@ class CrossingSupportSnapshotTest {
         assertTrue(summary.contains("lat=37.450123"))
         assertTrue(summary.contains("lon=127.128456"))
         assertTrue(summary.contains("acc=5.5m"))
+        assertTrue(summary.contains("heading=182"))
     }
 }

--- a/app/src/test/java/kr/co/gachon/pproject6/via/context/CrosswalkGuidanceMessageBuilderTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/context/CrosswalkGuidanceMessageBuilderTest.kt
@@ -1,0 +1,147 @@
+package kr.co.gachon.pproject6.via.context
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrosswalkGuidanceMessageBuilderTest {
+    @Test
+    fun guidanceIncludesDistanceAndForwardDirectionWhenHeadingIsKnown() {
+        val message =
+            CrosswalkGuidanceMessageBuilder.build(
+                CrossingSupportSnapshot(
+                    currentLocationLatitude = 37.0,
+                    currentLocationLongitude = 127.0,
+                    currentLocationAccuracyMeters = 8f,
+                    currentHeadingDegrees = 0f,
+                    mapProximitySnapshot = MapProximitySnapshot(
+                        matchedLatitude = 37.00009,
+                        matchedLongitude = 127.0,
+                        distanceMeters = 10f
+                    )
+                )
+        )
+
+        assertTrue(message.detail.contains("약 10미터"))
+        assertTrue(message.detail.contains("전방에"))
+    }
+
+    @Test
+    fun guidanceUsesRightSideDirectionRelativeToHeading() {
+        val message =
+            CrosswalkGuidanceMessageBuilder.build(
+                CrossingSupportSnapshot(
+                    currentLocationLatitude = 37.0,
+                    currentLocationLongitude = 127.0,
+                    currentLocationAccuracyMeters = 8f,
+                    currentHeadingDegrees = 0f,
+                    mapProximitySnapshot = MapProximitySnapshot(
+                        matchedLatitude = 37.0,
+                        matchedLongitude = 127.0001,
+                        distanceMeters = 9f
+                    )
+                )
+            )
+
+        assertTrue(message.detail.contains("오른쪽 방향"))
+    }
+
+    @Test
+    fun guidanceSuppressesDirectionWhenLocationAccuracyIsLow() {
+        val message =
+            CrosswalkGuidanceMessageBuilder.build(
+                CrossingSupportSnapshot(
+                    currentLocationLatitude = 37.0,
+                    currentLocationLongitude = 127.0,
+                    currentLocationAccuracyMeters = 50f,
+                    currentHeadingDegrees = 0f,
+                    mapProximitySnapshot = MapProximitySnapshot(
+                        matchedLatitude = 37.00009,
+                        matchedLongitude = 127.0,
+                        distanceMeters = 10f
+                    )
+                )
+            )
+
+        assertTrue(message.detail.contains("약 10미터 거리에 있습니다"))
+        assertTrue(message.detail.contains("방향 안내는 생략합니다"))
+    }
+
+    @Test
+    fun guidanceSuppressesDirectionWhenHeadingIsMissing() {
+        val message =
+            CrosswalkGuidanceMessageBuilder.build(
+                CrossingSupportSnapshot(
+                    currentLocationLatitude = 37.0,
+                    currentLocationLongitude = 127.0,
+                    currentLocationAccuracyMeters = 8f,
+                    currentHeadingDegrees = null,
+                    mapProximitySnapshot = MapProximitySnapshot(
+                        matchedLatitude = 37.00009,
+                        matchedLongitude = 127.0,
+                        distanceMeters = 10f
+                    )
+                )
+            )
+
+        assertTrue(message.detail.contains("약 10미터 거리에 있습니다"))
+        assertTrue(message.detail.contains("이동 방향을 아직 확인하지 못해"))
+        assertTrue(message.detail.contains("방향 안내는 생략합니다"))
+    }
+
+    @Test
+    fun guidanceReportsUnavailableWhenLocationIsMissing() {
+        val message =
+            CrosswalkGuidanceMessageBuilder.build(
+                CrossingSupportSnapshot(
+                    currentHeadingDegrees = 0f,
+                    mapProximitySnapshot = MapProximitySnapshot(
+                        matchedLatitude = 37.00009,
+                        matchedLongitude = 127.0,
+                        distanceMeters = 10f
+                    )
+                )
+            )
+
+        assertTrue(message.detail.contains("현재 위치를 확인하지 못했습니다"))
+    }
+
+    @Test
+    fun guidanceReportsUnavailableWhenNoMapMatchExists() {
+        val message =
+            CrosswalkGuidanceMessageBuilder.build(
+                CrossingSupportSnapshot(
+                    currentLocationLatitude = 37.0,
+                    currentLocationLongitude = 127.0,
+                    currentHeadingDegrees = 0f
+                )
+            )
+
+        assertTrue(message.detail.contains("횡단보도 정보가 없습니다"))
+    }
+
+    @Test
+    fun guidanceDoesNotClaimSignalStateOrCrossingPermission() {
+        val message =
+            CrosswalkGuidanceMessageBuilder.build(
+                CrossingSupportSnapshot(
+                    currentLocationLatitude = 37.0,
+                    currentLocationLongitude = 127.0,
+                    currentLocationAccuracyMeters = 8f,
+                    currentHeadingDegrees = 0f,
+                    mapProximitySnapshot = MapProximitySnapshot(
+                        matchedLatitude = 37.00009,
+                        matchedLongitude = 127.0,
+                        distanceMeters = 10f
+                    )
+                )
+            )
+
+        val forbiddenPhrases = listOf("초록", "빨간", "신호", "건너세요", "건너도")
+        forbiddenPhrases.forEach { phrase ->
+            assertTrue(
+                "message should not contain '$phrase': ${message.detail}",
+                !message.detail.contains(phrase)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add a main-screen “주변 횡단보도 안내” action that speaks/toasts nearest known crosswalk distance and relative direction.
- Expose current movement heading in `CrossingSupportSnapshot` and backfill location/bearing from last known location when needed.
- Keep crosswalk guidance separate from signal truth: no signal color or crossing-permission wording, and no mutation of the signal status text.

## Verification
- `./gradlew.bat --no-daemon --no-parallel --max-workers=1 testDebugUnitTest lintDebug assembleDebug` ✅ on temp verification copy `C:\Users\aheui\AppData\Local\Temp\via_verify_36`
- Architect review: APPROVED

## Notes
- The primary workspace currently has recurring Windows file locks in `app/build/intermediates/.../mergeDebugResources/merger.xml`; same source was verified in a clean temp copy.

Closes #36