### PR TITLE
Route Bluetooth Space input to safety actions

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -20,6 +20,7 @@ import android.view.Surface
 import android.view.TextureView
 import android.view.View
 import android.view.ViewGroup
+import android.view.KeyEvent
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
@@ -42,6 +43,8 @@ import kr.co.gachon.pproject6.via.feedback.SignalFeedbackManager
 import kr.co.gachon.pproject6.via.camera.CameraManager
 import kr.co.gachon.pproject6.via.context.CrossingSupportManager
 import kr.co.gachon.pproject6.via.context.CrossingSupportSnapshot
+import kr.co.gachon.pproject6.via.input.RemoteButtonAction
+import kr.co.gachon.pproject6.via.input.RemoteButtonPressClassifier
 import kr.co.gachon.pproject6.via.ml.AdvisoryAssessment
 import kr.co.gachon.pproject6.via.ml.AdvisoryState
 import kr.co.gachon.pproject6.via.ml.DetectionLabels
@@ -64,6 +67,7 @@ import kr.co.gachon.pproject6.via.map.KineticGuestSessionManager
 import kr.co.gachon.pproject6.via.map.MapDebugCacheManager
 import kr.co.gachon.pproject6.via.onboarding.AppPreferences
 import kr.co.gachon.pproject6.via.onboarding.OnboardingActivity
+import kr.co.gachon.pproject6.via.safety.EmergencyContactActivity
 import kr.co.gachon.pproject6.via.settings.SettingsActivity
 import kr.co.gachon.pproject6.via.ui.OverlayView
 import kr.co.gachon.pproject6.via.util.ImageUtils
@@ -145,6 +149,7 @@ class MainActivity : AppCompatActivity() {
     private val locationManager by lazy {
         getSystemService(LocationManager::class.java)
     }
+    private val remoteButtonClassifier = RemoteButtonPressClassifier()
     private var latestCrossingSupportSnapshot: CrossingSupportSnapshot = CrossingSupportSnapshot()
 
     private var cameraManager: CameraManager? = null
@@ -308,7 +313,7 @@ class MainActivity : AppCompatActivity() {
         tuningDebugText = findViewById(R.id.tuningDebugText)
         statusTitleText = findViewById(R.id.statusTitleText)
         statusDetailText = findViewById(R.id.statusDetailText)
-        addNearbyCrosswalkGuideButton()
+        addMainActionButtons()
         statusIconText = findViewById(R.id.statusIconText)
         statusBadgeText = findViewById(R.id.statusBadgeText)
         confidenceSliderLabel = findViewById(R.id.confidenceSliderLabel)
@@ -459,32 +464,80 @@ class MainActivity : AppCompatActivity() {
         setupModelSpinner()
     }
 
-    private fun addNearbyCrosswalkGuideButton(): MaterialButton {
+    private fun addMainActionButtons() {
         val statusContent =
             (statusPanel as? ViewGroup)?.getChildAt(0) as? LinearLayout
                 ?: error("statusPanel content must be a LinearLayout")
-        return MaterialButton(this).apply {
-            text = "주변 횡단보도 안내"
-            isAllCaps = false
-            textSize = 17f
-            minHeight = dp(56)
-            cornerRadius = dp(18)
-            layoutParams =
-                LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
-                ).apply {
-                    topMargin = dp(16)
-                }
-            setOnClickListener {
+        statusContent.addView(
+            mainActionButton("주변 횡단보도 안내") {
                 announceNearbyCrosswalk()
             }
-            statusContent.addView(this)
+        )
+        statusContent.addView(
+            mainActionButton("비상 문자 5초 유예") {
+                openEmergencyContact(autoStartCountdown = true)
+            }
+        )
+    }
+
+    private fun mainActionButton(
+        label: String,
+        onClick: () -> Unit
+    ): MaterialButton = MaterialButton(this).apply {
+        text = label
+        isAllCaps = false
+        textSize = 17f
+        minHeight = dp(56)
+        cornerRadius = dp(18)
+        layoutParams =
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            ).apply {
+                topMargin = dp(12)
+            }
+        setOnClickListener {
+            onClick()
         }
     }
 
     private fun dp(value: Int): Int {
         return (value * resources.displayMetrics.density).toInt()
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (event.keyCode != KeyEvent.KEYCODE_SPACE) {
+            return super.dispatchKeyEvent(event)
+        }
+
+        val action =
+            when (event.action) {
+                KeyEvent.ACTION_DOWN ->
+                    remoteButtonClassifier.onDown(
+                        eventTimeMs = event.eventTime,
+                        repeatCount = event.repeatCount
+                    )
+                KeyEvent.ACTION_UP ->
+                    remoteButtonClassifier.onUp(eventTimeMs = event.eventTime)
+                else -> null
+            }
+        action?.let { handleRemoteButtonAction(it) }
+        return true
+    }
+
+    private fun handleRemoteButtonAction(action: RemoteButtonAction) {
+        when (action) {
+            RemoteButtonAction.SHORT_PRESS -> {
+                Log.i("VIA_REMOTE", "Space short press: nearby crosswalk guidance")
+                Toast.makeText(this, "리모컨: 주변 횡단보도 안내", Toast.LENGTH_SHORT).show()
+                announceNearbyCrosswalk()
+            }
+            RemoteButtonAction.LONG_PRESS -> {
+                Log.i("VIA_REMOTE", "Space long press: emergency SMS countdown")
+                Toast.makeText(this, "리모컨: 비상 문자 5초 유예", Toast.LENGTH_SHORT).show()
+                openEmergencyContact(autoStartCountdown = true)
+            }
+        }
     }
 
     override fun onResume() {
@@ -1455,6 +1508,13 @@ class MainActivity : AppCompatActivity() {
             message = guidanceMessage.speechText,
             utteranceId = "nearby_crosswalk_guidance"
         )
+    }
+
+    private fun openEmergencyContact(autoStartCountdown: Boolean) {
+        val intent = Intent(this, EmergencyContactActivity::class.java).apply {
+            putExtra(EmergencyContactActivity.EXTRA_AUTO_START_COUNTDOWN, autoStartCountdown)
+        }
+        startActivity(intent)
     }
 
     private fun crosswalkGuidanceSnapshot(): CrossingSupportSnapshot {

--- a/app/src/main/java/kr/co/gachon/pproject6/via/input/RemoteButtonPressClassifier.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/input/RemoteButtonPressClassifier.kt
@@ -1,0 +1,69 @@
+package kr.co.gachon.pproject6.via.input
+
+enum class RemoteButtonAction {
+    SHORT_PRESS,
+    LONG_PRESS
+}
+
+class RemoteButtonPressClassifier(
+    private val longPressThresholdMs: Long = DEFAULT_LONG_PRESS_THRESHOLD_MS,
+    private val actionCooldownMs: Long = DEFAULT_ACTION_COOLDOWN_MS
+) {
+    private var downStartedAtMs: Long? = null
+    private var longPressEmittedForCurrentPress = false
+    private var lastActionAtMs: Long = Long.MIN_VALUE
+
+    fun onDown(eventTimeMs: Long, repeatCount: Int): RemoteButtonAction? {
+        if (repeatCount == 0 || downStartedAtMs == null) {
+            downStartedAtMs = eventTimeMs
+            longPressEmittedForCurrentPress = false
+            return null
+        }
+
+        val startedAt = downStartedAtMs ?: return null
+        return if (!longPressEmittedForCurrentPress &&
+            eventTimeMs - startedAt >= longPressThresholdMs
+        ) {
+            longPressEmittedForCurrentPress = true
+            emitIfNotCoolingDown(RemoteButtonAction.LONG_PRESS, eventTimeMs)
+        } else {
+            null
+        }
+    }
+
+    fun onUp(eventTimeMs: Long): RemoteButtonAction? {
+        val startedAt = downStartedAtMs
+        downStartedAtMs = null
+        if (startedAt == null || longPressEmittedForCurrentPress) {
+            longPressEmittedForCurrentPress = false
+            return null
+        }
+
+        val action =
+            if (eventTimeMs - startedAt >= longPressThresholdMs) {
+                RemoteButtonAction.LONG_PRESS
+            } else {
+                RemoteButtonAction.SHORT_PRESS
+            }
+        longPressEmittedForCurrentPress = false
+        return emitIfNotCoolingDown(action, eventTimeMs)
+    }
+
+    private fun emitIfNotCoolingDown(
+        action: RemoteButtonAction,
+        eventTimeMs: Long
+    ): RemoteButtonAction? {
+        if (lastActionAtMs != Long.MIN_VALUE &&
+            eventTimeMs - lastActionAtMs < actionCooldownMs
+        ) {
+            return null
+        }
+        lastActionAtMs = eventTimeMs
+        return action
+    }
+
+    companion object {
+        const val DEFAULT_LONG_PRESS_THRESHOLD_MS = 800L
+        const val DEFAULT_ACTION_COOLDOWN_MS = 1_200L
+    }
+}

--- a/app/src/main/java/kr/co/gachon/pproject6/via/safety/EmergencyContactActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/safety/EmergencyContactActivity.kt
@@ -75,12 +75,7 @@ class EmergencyContactActivity : AppCompatActivity() {
             Toast.makeText(this, "비상 연락처를 삭제했습니다.", Toast.LENGTH_SHORT).show()
         }
         sendButton.setOnClickListener {
-            if (!ensureContactSaved()) return@setOnClickListener
-            if (hasSmsPermission()) {
-                startEmergencyCountdown()
-            } else {
-                requestSmsPermissionLauncher.launch(Manifest.permission.SEND_SMS)
-            }
+            requestEmergencyCountdown()
         }
         cancelButton.setOnClickListener {
             cancelEmergencyCountdown()
@@ -89,6 +84,11 @@ class EmergencyContactActivity : AppCompatActivity() {
         views.openSmsAppButton.setOnClickListener {
             if (ensureContactSaved()) {
                 openSmsApp()
+            }
+        }
+        if (intent.getBooleanExtra(EXTRA_AUTO_START_COUNTDOWN, false)) {
+            views.root.post {
+                requestEmergencyCountdown()
             }
         }
     }
@@ -123,6 +123,17 @@ class EmergencyContactActivity : AppCompatActivity() {
             false
         } else {
             true
+        }
+    }
+
+    private fun requestEmergencyCountdown() {
+        if (!ensureContactSaved()) {
+            return
+        }
+        if (hasSmsPermission()) {
+            startEmergencyCountdown()
+        } else {
+            requestSmsPermissionLauncher.launch(Manifest.permission.SEND_SMS)
         }
     }
 
@@ -401,8 +412,10 @@ class EmergencyContactActivity : AppCompatActivity() {
     private fun dp(value: Int): Int =
         (value * resources.displayMetrics.density).toInt()
 
-    private companion object {
+    companion object {
         private const val AUTO_SEND_DELAY_MS = 5_000L
+        const val EXTRA_AUTO_START_COUNTDOWN =
+            "kr.co.gachon.pproject6.via.safety.AUTO_START_COUNTDOWN"
     }
 }
 

--- a/app/src/main/java/kr/co/gachon/pproject6/via/settings/SettingsActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/settings/SettingsActivity.kt
@@ -48,7 +48,7 @@ class SettingsActivity : AppCompatActivity() {
             startActivity(Intent(this, EmergencyContactActivity::class.java))
         }
         findViewById<MaterialButton>(R.id.bluetoothGuideButton).setOnClickListener {
-            showNextIssueToast("블루투스 버튼 안내/테스트는 #35에서 연결됩니다.")
+            showNextIssueToast("Space 짧게: 횡단보도 안내 · 길게: 비상 문자 5초 유예")
         }
         findViewById<MaterialButton>(R.id.usageGuideButton).setOnClickListener {
             showNextIssueToast("앱 사용 안내는 #38에서 정리됩니다.")

--- a/app/src/test/java/kr/co/gachon/pproject6/via/input/RemoteButtonPressClassifierTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/input/RemoteButtonPressClassifierTest.kt
@@ -1,0 +1,50 @@
+package kr.co.gachon.pproject6.via.input
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RemoteButtonPressClassifierTest {
+    @Test
+    fun shortPressEmitsShortActionOnKeyUp() {
+        val classifier = RemoteButtonPressClassifier()
+
+        assertNull(classifier.onDown(eventTimeMs = 1_000L, repeatCount = 0))
+
+        assertEquals(RemoteButtonAction.SHORT_PRESS, classifier.onUp(eventTimeMs = 1_200L))
+    }
+
+    @Test
+    fun longPressOnKeyUpDoesNotAlsoEmitShortPress() {
+        val classifier = RemoteButtonPressClassifier()
+
+        assertNull(classifier.onDown(eventTimeMs = 1_000L, repeatCount = 0))
+
+        assertEquals(RemoteButtonAction.LONG_PRESS, classifier.onUp(eventTimeMs = 1_900L))
+        assertNull(classifier.onUp(eventTimeMs = 1_950L))
+    }
+
+    @Test
+    fun repeatedKeyDownCanEmitLongPressBeforeKeyUp() {
+        val classifier = RemoteButtonPressClassifier()
+
+        assertNull(classifier.onDown(eventTimeMs = 1_000L, repeatCount = 0))
+        assertEquals(
+            RemoteButtonAction.LONG_PRESS,
+            classifier.onDown(eventTimeMs = 1_850L, repeatCount = 1)
+        )
+
+        assertNull(classifier.onUp(eventTimeMs = 1_900L))
+    }
+
+    @Test
+    fun cooldownSuppressesImmediateSecondAction() {
+        val classifier = RemoteButtonPressClassifier()
+
+        classifier.onDown(eventTimeMs = 1_000L, repeatCount = 0)
+        assertEquals(RemoteButtonAction.SHORT_PRESS, classifier.onUp(eventTimeMs = 1_100L))
+        classifier.onDown(eventTimeMs = 1_500L, repeatCount = 0)
+
+        assertNull(classifier.onUp(eventTimeMs = 1_600L))
+    }
+}


### PR DESCRIPTION
## Summary
- Handle Space key events from Bluetooth remotes as short/long press actions.
- Short press calls nearby crosswalk distance/direction guidance; long press opens the emergency SMS flow with auto-started 5-second countdown.
- Add screen buttons for the same crosswalk/emergency actions so non-remote users remain covered.
- Add classifier unit tests for short press, long press, duplicate suppression, and cooldown.

## Verification
- `./gradlew.bat --no-daemon --no-parallel --max-workers=1 testDebugUnitTest lintDebug assembleDebug` ✅ on temp verification copy `C:\Users\aheui\AppData\Local\Temp\via_verify_35`
- Architect review: APPROVED

## Notes
- Main workspace still has recurring Windows `app/build` file lock issues; clean temp copy was used for verification.

Closes #35