### PR TITLE
Clarify onboarding and add usage guide

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,10 @@
             android:exported="false"
             android:screenOrientation="portrait" />
         <activity
+            android:name=".guide.UsageGuideActivity"
+            android:exported="false"
+            android:screenOrientation="portrait" />
+        <activity
             android:name=".DebugMapActivity"
             android:exported="false"
             android:screenOrientation="portrait" />

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
@@ -1,0 +1,111 @@
+package kr.co.gachon.pproject6.via.guide
+
+import android.os.Bundle
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
+import kr.co.gachon.pproject6.via.R
+
+class UsageGuideActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(createContentView())
+    }
+
+    private fun createContentView(): ScrollView {
+        val root = ScrollView(this).apply {
+            setBackgroundColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_background))
+            isFillViewport = true
+        }
+        val content = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20), dp(28), dp(20), dp(32))
+        }
+        root.addView(content, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+
+        content.addView(textButton("← 설정으로 돌아가기").apply { setOnClickListener { finish() } })
+        content.addView(titleText("앱 사용 안내"), matchWrap(topMargin = 8))
+        content.addView(
+            bodyText("VIA는 보행 판단을 대신하지 않고, 신호·횡단보도·비상 연락을 보조적으로 안내합니다."),
+            matchWrap(topMargin = 8)
+        )
+
+        UsageGuideContent.sections.forEach { section ->
+            content.addView(
+                card {
+                    addView(sectionTitleText(section.title), matchWrap())
+                    addView(bodyText(section.body), matchWrap(topMargin = 8))
+                },
+                matchWrap(topMargin = 16)
+            )
+        }
+        return root
+    }
+
+    private fun card(contentBuilder: LinearLayout.() -> Unit): MaterialCardView {
+        val cardContent = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(dp(20), dp(20), dp(20), dp(20))
+            contentBuilder()
+        }
+        return MaterialCardView(this).apply {
+            radius = dp(24).toFloat()
+            cardElevation = 0f
+            setCardBackgroundColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_surface))
+            strokeColor = ContextCompat.getColor(this@UsageGuideActivity, R.color.via_surface_outline)
+            strokeWidth = dp(1)
+            addView(cardContent, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        }
+    }
+
+    private fun titleText(text: String): TextView =
+        TextView(this).apply {
+            this.text = text
+            setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))
+            textSize = 34f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+        }
+
+    private fun sectionTitleText(text: String): TextView =
+        TextView(this).apply {
+            this.text = text
+            setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))
+            textSize = 22f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+        }
+
+    private fun bodyText(text: String): TextView =
+        TextView(this).apply {
+            this.text = text
+            setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface_variant))
+            textSize = 16f
+            setLineSpacing(dp(4).toFloat(), 1f)
+        }
+
+    private fun textButton(text: String): MaterialButton =
+        MaterialButton(this, null, com.google.android.material.R.attr.borderlessButtonStyle).apply {
+            this.text = text
+            isAllCaps = false
+            textSize = 16f
+            minHeight = dp(48)
+            setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))
+        }
+
+    private fun matchWrap(topMargin: Int = 0): LinearLayout.LayoutParams =
+        LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        ).apply {
+            if (topMargin > 0) {
+                setMargins(0, dp(topMargin), 0, 0)
+            }
+        }
+
+    private fun dp(value: Int): Int =
+        (value * resources.displayMetrics.density).toInt()
+}

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideContent.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideContent.kt
@@ -1,0 +1,40 @@
+package kr.co.gachon.pproject6.via.guide
+
+data class UsageGuideSection(
+    val title: String,
+    val body: String
+)
+
+object UsageGuideContent {
+    val sections: List<UsageGuideSection> =
+        listOf(
+            UsageGuideSection(
+                title = "VIA가 하는 일",
+                body = "VIA는 보행자 신호와 주변 횡단보도 정보를 보조적으로 안내합니다. 실제 이동 전에는 반드시 차량, 자전거, 주변 사람, 노면 상태를 직접 확인해야 합니다."
+            ),
+            UsageGuideSection(
+                title = "중요 안전 안내",
+                body = "VIA는 보행 판단을 보조하는 앱이며 최종 판단을 대신하지 않습니다. 안내가 불확실하거나 주변 상황과 다르면 멈추고 주변 도움을 요청해 주세요."
+            ),
+            UsageGuideSection(
+                title = "권한을 쓰는 이유",
+                body = "카메라는 보행자 신호를 확인하는 데 사용합니다. 위치는 가까운 횡단보도 거리와 방향을 안내하는 데 사용합니다. SMS 권한은 사용자가 등록한 보호자나 기관에 비상 문자를 자동 발송할 때만 사용합니다."
+            ),
+            UsageGuideSection(
+                title = "주요 기능",
+                body = "신호 상태 안내는 카메라로 보이는 보행자 신호를 음성과 화면으로 알려줍니다. 주변 횡단보도 안내는 현재 위치 기준 가까운 횡단보도의 거리와 방향만 알려줍니다. 비상 문자는 5초 유예 후 등록된 연락처로 발송되며 취소할 수 있습니다."
+            ),
+            UsageGuideSection(
+                title = "블루투스 버튼",
+                body = "Space 키로 동작하는 블루투스 버튼을 사용할 수 있습니다. 짧게 누르면 주변 횡단보도 안내를 실행하고, 길게 누르면 비상 문자 5초 유예 화면을 엽니다. 화면 버튼으로도 같은 기능을 사용할 수 있습니다."
+            ),
+            UsageGuideSection(
+                title = "상태 문구의 의미",
+                body = "초록으로 보임은 카메라에서 보행자 초록 신호가 확인된 상태입니다. 빨간색으로 보임은 보행자 빨간 신호가 확인된 상태입니다. 신호 확인 불확실은 카메라 시야나 인식 신뢰도가 부족한 상태입니다. 다음 신호 대기 권장은 새로운 신호 주기를 기다리는 것이 더 안전하다는 뜻입니다."
+            ),
+            UsageGuideSection(
+                title = "초기 최적화",
+                body = "첫 실행 시 앱은 기기에서 사용할 AI 모델과 실행 방식을 짧게 측정합니다. 측정 중에는 휴대폰을 안정적으로 들고 카메라 권한을 유지해 주세요. 설정의 디버그 패널에서 모델과 FPS를 다시 확인할 수 있습니다."
+            )
+        )
+}

--- a/app/src/main/java/kr/co/gachon/pproject6/via/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/onboarding/OnboardingActivity.kt
@@ -181,9 +181,9 @@ class OnboardingActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         progressBar.visibility = View.GONE
         progressText.visibility = View.GONE
         stepLabelText.text = "1 / 3 · 시작 안내"
-        titleText.text = "처음 설정을 시작합니다"
-        bodyText.text = "앱 설정 절차를 진행합니다."
-        detailText.text = "몇 가지 확인이 끝나면 바로 사용할 수 있습니다."
+        titleText.text = "VIA 사용 전 안내"
+        bodyText.text = "VIA는 보행자 신호와 주변 횡단보도 정보를 보조적으로 안내합니다."
+        detailText.text = "실제 이동 전에는 반드시 주변 차량과 상황을 직접 확인해야 합니다."
         actionButton.isEnabled = true
         actionButton.text = "다음"
         secondaryButton.visibility = View.VISIBLE
@@ -201,8 +201,8 @@ class OnboardingActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         progressText.visibility = View.GONE
         stepLabelText.text = "2 / 3 · 권한 허용"
         titleText.text = "권한이 필요합니다"
-        bodyText.text = "카메라와 위치 권한을 허용해 주세요."
-        detailText.text = detailOverride ?: "허용 버튼을 누르면 다음 단계로 진행합니다."
+        bodyText.text = "카메라는 보행자 신호 확인, 위치는 주변 횡단보도 안내에 사용합니다."
+        detailText.text = detailOverride ?: "비상 문자는 설정에서 연락처를 등록한 뒤 SMS 권한을 요청합니다."
         actionButton.isEnabled = true
         actionButton.text = "권한 허용"
         secondaryButton.visibility = View.VISIBLE
@@ -264,8 +264,8 @@ class OnboardingActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         progressBar.progress = 0
         stepLabelText.text = "3 / 3 · 자동 최적화"
         titleText.text = "설정을 확인하는 중입니다"
-        bodyText.text = "이 기기에서 가장 잘 맞는 설정을 찾고 있습니다."
-        detailText.text = "잠시만 기다려 주세요."
+        bodyText.text = "이 기기에서 사용할 AI 모델과 실행 방식을 짧게 측정합니다."
+        detailText.text = "휴대폰을 안정적으로 들고 잠시만 기다려 주세요."
         actionButton.isEnabled = false
         actionButton.text = "측정 중"
         secondaryButton.visibility = View.VISIBLE
@@ -460,7 +460,7 @@ class OnboardingActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         stepLabelText.text = "완료"
         titleText.text = "설정이 완료되었습니다"
         bodyText.text = bestResult.profile.fileName
-        detailText.text = "${bestResult.backendLabel} 가속 / ${"%.1f".format(bestResult.averageDetectFps)} FPS"
+        detailText.text = "${bestResult.backendLabel} / ${"%.1f".format(bestResult.averageDetectFps)} FPS · 설정에서 사용 안내를 다시 볼 수 있습니다."
         actionButton.isEnabled = true
         actionButton.text = "시작하기"
         secondaryButton.visibility = View.VISIBLE
@@ -474,13 +474,13 @@ class OnboardingActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         if (!ttsReady) return
         val message = when (currentStep) {
             Step.INTRO ->
-                "처음 설정을 시작합니다. 앱 설정 절차를 진행합니다. 다음 버튼을 눌러 진행해 주세요."
+                "VIA는 보행자 신호와 주변 횡단보도 정보를 보조적으로 안내합니다. 실제 이동 전에는 주변 상황을 반드시 확인해 주세요."
             Step.PERMISSION ->
-                "카메라와 위치 권한을 허용해 주세요. 허용 버튼을 눌러 진행해 주세요."
+                "카메라는 보행자 신호 확인에, 위치는 주변 횡단보도 안내에 사용합니다. 허용 버튼을 눌러 진행해 주세요."
             Step.CALIBRATING ->
-                "설정을 확인하는 중입니다. 잠시만 기다려 주세요."
+                "기기에서 사용할 AI 모델과 실행 방식을 측정하는 중입니다. 잠시만 기다려 주세요."
             Step.RESULT ->
-                "설정이 완료되었습니다. 시작하기 버튼으로 시작하거나 다시 측정하기 버튼으로 다시 측정할 수 있습니다."
+                "설정이 완료되었습니다. 설정 화면에서 사용 안내를 다시 볼 수 있습니다."
         }
         if (!forceReplay && spokenMessage == message) return
         spokenMessage = message

--- a/app/src/main/java/kr/co/gachon/pproject6/via/settings/SettingsActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/settings/SettingsActivity.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.switchmaterial.SwitchMaterial
 import kr.co.gachon.pproject6.via.R
+import kr.co.gachon.pproject6.via.guide.UsageGuideActivity
 import kr.co.gachon.pproject6.via.map.MapDebugCacheManager
 import kr.co.gachon.pproject6.via.onboarding.AppPreferences
 import kr.co.gachon.pproject6.via.safety.EmergencyContactActivity
@@ -51,7 +52,7 @@ class SettingsActivity : AppCompatActivity() {
             showNextIssueToast("Space 짧게: 횡단보도 안내 · 길게: 비상 문자 5초 유예")
         }
         findViewById<MaterialButton>(R.id.usageGuideButton).setOnClickListener {
-            showNextIssueToast("앱 사용 안내는 #38에서 정리됩니다.")
+            startActivity(Intent(this, UsageGuideActivity::class.java))
         }
         findViewById<MaterialButton>(R.id.openDebugPanelButton).setOnClickListener {
             setResult(

--- a/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
@@ -1,0 +1,39 @@
+package kr.co.gachon.pproject6.via.guide
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UsageGuideContentTest {
+    @Test
+    fun guideExplainsRolePermissionsAndMajorFeatures() {
+        val content = fullGuideText()
+
+        listOf("보조", "카메라", "위치", "SMS", "신호", "횡단보도", "비상 문자", "블루투스").forEach { keyword ->
+            assertTrue("guide should contain $keyword", content.contains(keyword))
+        }
+    }
+
+    @Test
+    fun guideIncludesClearSafetyDisclaimer() {
+        val content = fullGuideText()
+
+        assertTrue(content.contains("최종 판단을 대신하지 않습니다"))
+        assertTrue(content.contains("주변 상황"))
+    }
+
+    @Test
+    fun guideDoesNotSayCrossingIsGuaranteedSafe() {
+        val content = fullGuideText()
+        val forbiddenPhrases = listOf("건너도 된다", "안전하게 건너", "무조건 건너")
+
+        forbiddenPhrases.forEach { phrase ->
+            assertTrue("guide should not contain '$phrase'", !content.contains(phrase))
+        }
+    }
+
+    private fun fullGuideText(): String {
+        return UsageGuideContent.sections.joinToString("\n") { section ->
+            "${section.title}\n${section.body}"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Update onboarding copy to explain VIA as assistive guidance, not a crossing-safety decision maker.
- Add a settings-accessible usage guide covering permissions, signal states, crosswalk guidance, emergency SMS, Bluetooth controls, and initial optimization.
- Add guide content tests for required topics and forbidden safety-promise wording.

## Verification
- `./gradlew.bat --no-daemon --no-parallel --max-workers=1 testDebugUnitTest lintDebug assembleDebug` ✅ on temp verification copy `C:\Users\aheui\AppData\Local\Temp\via_verify_38`
- Architect review: APPROVED

## Notes
- Main workspace still has recurring Windows `app/build` file lock issues; clean temp copy was used for verification.

Closes #38