### PR TITLE
Polish main guidance UI for low-vision use

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -469,12 +469,18 @@ class MainActivity : AppCompatActivity() {
             (statusPanel as? ViewGroup)?.getChildAt(0) as? LinearLayout
                 ?: error("statusPanel content must be a LinearLayout")
         statusContent.addView(
-            mainActionButton("주변 횡단보도 안내") {
+            mainActionButton(
+                label = "주변 횡단보도 안내",
+                description = "가까운 횡단보도 거리와 방향 안내"
+            ) {
                 announceNearbyCrosswalk()
             }
         )
         statusContent.addView(
-            mainActionButton("비상 문자 5초 유예") {
+            mainActionButton(
+                label = "비상 연락",
+                description = "비상 문자 5초 유예 화면 열기"
+            ) {
                 openEmergencyContact(autoStartCountdown = true)
             }
         )
@@ -482,19 +488,21 @@ class MainActivity : AppCompatActivity() {
 
     private fun mainActionButton(
         label: String,
+        description: String,
         onClick: () -> Unit
     ): MaterialButton = MaterialButton(this).apply {
         text = label
+        contentDescription = description
         isAllCaps = false
         textSize = 17f
-        minHeight = dp(56)
+        minHeight = dp(64)
         cornerRadius = dp(18)
         layoutParams =
             LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT
             ).apply {
-                topMargin = dp(12)
+                topMargin = dp(14)
             }
         setOnClickListener {
             onClick()
@@ -1598,6 +1606,7 @@ class MainActivity : AppCompatActivity() {
             statusTitleText.text = "분석 일시중지"
             statusTitleText.setTextColor(Color.WHITE)
             statusDetailText.text = "신호 인식이 일시중지되었습니다"
+            statusPanel.contentDescription = "현재 상태: 분석 일시중지. 신호 인식이 일시중지되었습니다."
             return
         }
         statusTitleText.text = analysisResult.advisoryTitleText
@@ -1611,6 +1620,8 @@ class MainActivity : AppCompatActivity() {
             }
         )
         statusDetailText.text = analysisResult.advisoryDetailText
+        statusPanel.contentDescription =
+            "현재 상태: ${analysisResult.advisoryTitleText}. ${analysisResult.advisoryDetailText}"
     }
 
     private fun updateStatusVisuals(
@@ -1622,6 +1633,7 @@ class MainActivity : AppCompatActivity() {
             statusTintOverlay.setBackgroundColor(Color.TRANSPARENT)
             statusTintOverlay.alpha = 0f
             statusIconText.text = "?"
+            statusIconText.contentDescription = "분석 일시중지"
             statusIconText.setTextColor(ContextCompat.getColor(this, R.color.via_on_surface))
             statusIconText.backgroundTintList =
                 ColorStateList.valueOf(ContextCompat.getColor(this, R.color.via_status_wait))
@@ -1636,10 +1648,12 @@ class MainActivity : AppCompatActivity() {
         statusTintOverlay.setBackgroundColor(tintColor)
         statusTintOverlay.alpha = if (tintColor == Color.TRANSPARENT) 0f else 1f
         statusIconText.text = visualState.iconText
+        statusIconText.contentDescription = statusTitleText.text
         statusIconText.setTextColor(visualState.iconTextColor)
         statusIconText.backgroundTintList = ColorStateList.valueOf(visualState.iconBackgroundColor)
         statusBadgeText.visibility = if (visualState.badgeText != null) View.VISIBLE else View.GONE
         statusBadgeText.text = visualState.badgeText ?: ""
+        statusBadgeText.contentDescription = visualState.badgeText ?: ""
     }
 
     private fun deriveStatusVisualState(
@@ -1658,10 +1672,10 @@ class MainActivity : AppCompatActivity() {
 
             analysisResult.advisoryState == AdvisoryState.GREEN_WITH_CAUTION ->
                 StatusVisualState(
-                    iconText = "▶",
-                    iconBackgroundColor = ContextCompat.getColor(this, R.color.via_status_go),
-                    iconTextColor = ContextCompat.getColor(this, R.color.via_on_primary),
-                    tintColor = Color.TRANSPARENT,
+                    iconText = "!",
+                    iconBackgroundColor = ContextCompat.getColor(this, R.color.via_status_caution),
+                    iconTextColor = ContextCompat.getColor(this, R.color.via_status_badge_on),
+                    tintColor = Color.parseColor("#3DFFC857"),
                     borderResId = R.drawable.border_green,
                     badgeText = "차량 주의"
                 )

--- a/app/src/main/java/kr/co/gachon/pproject6/via/ml/SignalAdvisoryEvaluator.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/ml/SignalAdvisoryEvaluator.kt
@@ -94,17 +94,17 @@ class SignalAdvisoryEvaluator(
 
         val titleText =
             when (state) {
-                AdvisoryState.RED_CONFIRMED -> "빨간불이 확인됩니다"
-                AdvisoryState.GREEN_CONFIRMED -> "초록불이 확인됩니다"
-                AdvisoryState.GREEN_WITH_CAUTION -> "초록불이 확인되지만 주의가 필요합니다"
-                AdvisoryState.TRANSITION_WAIT -> "다음 신호 전환을 기다립니다"
+                AdvisoryState.RED_CONFIRMED -> "보행자 신호 빨간색으로 보임"
+                AdvisoryState.GREEN_CONFIRMED -> "보행자 신호 초록으로 보임"
+                AdvisoryState.GREEN_WITH_CAUTION -> "초록으로 보이나 주의 필요"
+                AdvisoryState.TRANSITION_WAIT -> "다음 신호 대기 권장"
                 AdvisoryState.UNCERTAIN_VIEW ->
                     when {
                         result.vehicleTrafficLightCount > 0 && result.trafficLightCount == 0 ->
                             "차량 신호가 보여 보행자 신호 확인이 필요합니다"
                         result.multipleSignalDetected -> "신호등이 여러 개 보여 추가 확인이 필요합니다"
                         result.needsZoomSuggestion -> "신호가 작게 보여 더 가까이 비춰주세요"
-                        else -> "신호 확인이 불안정합니다"
+                        else -> "신호 확인 불확실"
                     }
             }
 

--- a/app/src/test/java/kr/co/gachon/pproject6/via/ml/SignalAdvisoryEvaluatorTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/ml/SignalAdvisoryEvaluatorTest.kt
@@ -50,6 +50,7 @@ class SignalAdvisoryEvaluatorTest {
 
         assertEquals(AdvisoryState.GREEN_CONFIRMED, advisory.state)
         assertEquals(AdvisoryConfidenceLevel.HIGH, advisory.confidenceLevel)
+        assertEquals("보행자 신호 초록으로 보임", advisory.titleText)
     }
 
     @Test
@@ -82,7 +83,25 @@ class SignalAdvisoryEvaluatorTest {
         val advisory = evaluator.evaluate(result)
 
         assertEquals(AdvisoryState.GREEN_WITH_CAUTION, advisory.state)
+        assertEquals("초록으로 보이나 주의 필요", advisory.titleText)
         assertTrue(advisory.detailText.contains("점유"))
+    }
+
+    @Test
+    fun lowVisionTitlesUseConsistentStateLanguage() {
+        val red = evaluator.evaluate(baseResult(trafficState = TrafficLightState.RED))
+        val wait =
+            evaluator.evaluate(
+                baseResult(
+                    trafficState = TrafficLightState.GREEN,
+                    guidanceBlockReason = GuidanceBlockReason.NEED_RED_BASELINE
+                )
+            )
+        val uncertain = evaluator.evaluate(baseResult(trafficState = TrafficLightState.UNKNOWN))
+
+        assertEquals("보행자 신호 빨간색으로 보임", red.titleText)
+        assertEquals("다음 신호 대기 권장", wait.titleText)
+        assertEquals("신호 확인 불확실", uncertain.titleText)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Normalize user-facing state titles for green seen, red seen, uncertain view, and next-signal wait.
- Enlarge and describe main action buttons for nearby crosswalk guidance and emergency contact.
- Add accessibility descriptions for the status card/icon/badge and make caution visually distinct from confirmed green.
- Add tests for the low-vision state wording.

## Verification
- `./gradlew.bat --no-daemon --no-parallel --max-workers=1 testDebugUnitTest lintDebug assembleDebug` ✅ on temp verification copy `C:\Users\aheui\AppData\Local\Temp\via_verify_39`
- Architect review: APPROVED

## Notes
- Main workspace still has recurring Windows `app/build` file lock issues; clean temp copy was used for verification.

Closes #39