### PR TITLE
chore(perf): make YOLO26n FPS regression measurable

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloDetector.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloDetector.kt
@@ -182,6 +182,15 @@ class YoloDetector(
         outputIsTransposed = outputShape[1] > outputShape[2]
         outputRows = if (outputIsTransposed) outputShape[1] else outputShape[2]
         outputCols = if (outputIsTransposed) outputShape[2] else outputShape[1]
+        Log.i(
+            TAG,
+            "model_io model=$modelPath backend=$runtimeBackendLabel requestedGpu=$useGpu " +
+                "compat=$compatibilityReportedSupported input=${inputShape.contentToString()} " +
+                "inputType=$inputDataType output=${outputShape.contentToString()} " +
+                "outputType=$outputDataType rows=$outputRows cols=$outputCols " +
+                "transposed=$outputIsTransposed " +
+                "layout=${YoloOutputParser.layoutName(outputCols, labels)} labels=${labels.size}"
+        )
         inputBuffer =
             ByteBuffer.allocateDirect(inputShape.product() * inputDataType.byteSize())
                 .order(ByteOrder.nativeOrder())

--- a/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloOutputParser.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloOutputParser.kt
@@ -14,6 +14,14 @@ data class ParsedYoloDetection(
 )
 
 object YoloOutputParser {
+    fun layoutName(outputCols: Int, labels: List<String>): String {
+        return if (isBatchedNmsLayout(outputCols, labels)) {
+            "batched_nms_xyxy_score_class"
+        } else {
+            "class_score_cxcywh"
+        }
+    }
+
     fun parse(
         output: FloatArray,
         outputRows: Int,

--- a/app/src/test/java/kr/co/gachon/pproject6/via/ml/YoloOutputParserTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/ml/YoloOutputParserTest.kt
@@ -6,6 +6,28 @@ import org.junit.Test
 
 class YoloOutputParserTest {
     @Test
+    fun layoutNameDescribesYolo26nBatchedNmsOutput() {
+        assertEquals(
+            "batched_nms_xyxy_score_class",
+            YoloOutputParser.layoutName(
+                outputCols = 6,
+                labels = DetectionLabels.sevenClassLabels
+            )
+        )
+    }
+
+    @Test
+    fun layoutNameKeepsSixColumnTwoClassOutputAsClassScore() {
+        assertEquals(
+            "class_score_cxcywh",
+            YoloOutputParser.layoutName(
+                outputCols = 6,
+                labels = listOf(DetectionLabels.HUMAN_RED, DetectionLabels.HUMAN_GREEN)
+            )
+        )
+    }
+
+    @Test
     fun yolo26nBatchedNmsLayoutUsesScoreAndClassIdColumns() {
         val detections =
             YoloOutputParser.parse(

--- a/resources/validation/yolo26n-7cls-v2-adoption-2026-05-14.md
+++ b/resources/validation/yolo26n-7cls-v2-adoption-2026-05-14.md
@@ -28,7 +28,7 @@
 - Android asset의 기존 `best_7cls_v2_*` TFLite 후보를 `best_yolo26n_7cls_v2_*` 후보로 교체한다.
 - `DetectionLabels.modelFilesForActiveSchema()`는 YOLO26n 7cls 후보가 있으면 해당 파일만 모델 선택/온보딩 calibration에 노출한다.
 - Class id 순서는 기존 7cls와 동일하므로 detector 후처리/label mapping은 변경하지 않는다.
-- 출력 shape도 `[1, 300, 6]`로 기존 TFLite parser를 그대로 사용한다.
+- 출력 shape `[1, 300, 6]`은 NMS 포함 layout으로 보고 `score, classId` 컬럼을 분기 파싱한다.
 
 ## 포함 모델
 | 파일 | 입력 크기 | 용도 |
@@ -40,6 +40,11 @@
 | `best_yolo26n_7cls_v2_float16_320.tflite` | 320 | 속도 우선 float16 |
 | `best_yolo26n_7cls_v2_int8_640.tflite` | 640 | 경량/정확도 절충 int8 |
 | `best_yolo26n_7cls_v2_int8_320.tflite` | 320 | 최경량/속도 우선 int8 |
+
+## 후속 런타임 주의사항
+- GitHub Issue #58에서 YOLO26n 640 float16 처리 FPS 저하를 별도로 추적한다.
+- 전달된 YOLO26n TFLite 출력 `[1, 300, 6]`은 앱에서 `x1, y1, x2, y2, score, classId` 형태의 NMS 포함 export로 해석한다.
+- 이 layout은 class id가 confidence처럼 표시되는 문제는 해결됐지만, Android TFLite GPU delegate에서는 NMS 포함 그래프가 raw-output export보다 느릴 수 있으므로 실측 비교가 필요하다.
 
 ## 검증 체크리스트
 - [ ] 온보딩 calibration에서 YOLO26n 후보만 측정되는지 확인

--- a/resources/validation/yolo26n-runtime-fps-investigation-2026-05-14.md
+++ b/resources/validation/yolo26n-runtime-fps-investigation-2026-05-14.md
@@ -1,0 +1,78 @@
+# YOLO26n runtime FPS investigation — 2026-05-14
+
+## Related issue
+- GitHub Issue: #58
+- Base branch: `fix/53-s25-red-led-flicker-artifact`
+- Investigation branch: `investigate/58-yolo26n-runtime-fps`
+
+## Symptom
+After adopting YOLO26n 7cls v2, the 640 float16 candidate is noticeably slower than expected in the realtime Android path. The previous 7cls 640 float16 path had been calibrated around the mid-20 FPS range, while the YOLO26n 640 float16 path was observed around the high single-digit to low double-digit processed FPS range. Switching to the YOLO26n 320 float16 candidate recovers throughput.
+
+This should not be treated as proof that YOLO26n itself is heavier. Runtime export layout and delegate compatibility can dominate Android TFLite latency.
+
+## Evidence already available
+From `resources/models/yolo26n_7cls_v2/manifest.txt`, every delivered YOLO26n TFLite candidate has the same output shape:
+
+| Model family | Input | Output |
+| --- | ---: | --- |
+| YOLO26n 7cls v2 float16 | 320..640 | `[1, 300, 6]` |
+| YOLO26n 7cls v2 int8 | 320/640 | `[1, 300, 6]` |
+
+The app parser now treats this six-column seven-class output as an NMS-included layout:
+
+```text
+x1, y1, x2, y2, score, classId
+```
+
+That fixed the earlier symptom where class ids such as `2.00` and `6.00` were displayed as confidence scores. However, it also means the exported TFLite graph may contain detection post-processing/NMS operations instead of exposing raw YOLO class-score tensors to the app.
+
+## Flatbuffer inspection snapshot
+A local TFLite flatbuffer metadata check separates the previous raw-output export from the delivered YOLO26n export:
+
+| Candidate | Output tensor | Operator count | Runtime-relevant operator clue |
+| --- | --- | ---: | --- |
+| Previous YOLO11n 7cls v2 640 float16 | `[1, 11, 8400]` | 546 | raw class-score tensor; no `TOPK_V2` in graph |
+| YOLO26n 7cls v2 640 float16 | `[1, 300, 6]` | 685 | NMS-like tail includes `TOPK_V2`, `GATHER_ND`, `TILE`, `FLOOR_MOD` |
+
+This confirms that the new Android delivery is not just a smaller backbone swap. It changes the TFLite output contract from raw predictions to a post-processed top-300 detection tensor, so runtime speed must be measured as an export/runtime property, not inferred from model size alone.
+
+## Working hypothesis
+The FPS drop is likely caused by one or more of these runtime factors:
+
+1. NMS/detection-postprocess operations embedded in the TFLite graph are not fully accelerated by the GPU delegate.
+2. Mixed GPU/CPU execution introduces synchronization overhead even when the convolutional backbone is smaller.
+3. The 640 candidate also drives the app analysis resolution to the 960x720 path, increasing camera bitmap conversion and resize cost before inference.
+4. File size is not a sufficient predictor of TFLite runtime speed when the operator graph changes.
+
+## Current code support added for retest
+`YoloDetector.setup()` now logs a single `VIA_GPU model_io` line after interpreter initialization. The line includes:
+
+- model file name
+- selected runtime backend
+- requested GPU flag
+- GPU delegate compatibility report
+- input shape and dtype
+- output shape and dtype
+- normalized row/column interpretation
+- parser layout name
+- label count
+
+Expected YOLO26n 7cls v2 640 log signature:
+
+```text
+layout=batched_nms_xyxy_score_class labels=7 output=[1, 300, 6]
+```
+
+A raw YOLO export should instead show a class-score layout such as `layout=class_score_cxcywh` with columns equal to `4 + classCount` after normalization.
+
+## Retest plan
+1. Run the same realtime route with YOLO26n float16 320/416/448/512/640.
+2. Record Camera FPS, Processed FPS, latency, model name, backend, analysis resolution, and the new `model_io` log line.
+3. Compare YOLO26n NMS-included 640 against a future NMS-free YOLO26n 640 export if available.
+4. Keep the 320 candidate as a temporary field-test workaround only; do not permanently lower the default until the export/runtime cause is decided.
+5. If NMS-free YOLO26n restores expected throughput, prefer raw-output export plus app-side NMS for Android delivery.
+
+## Acceptance criteria for closing #58
+- The 640 FPS regression is attributed to either export layout/delegate compatibility, analysis resolution cost, or model compute cost with evidence.
+- The team decides whether Android should use NMS-included or NMS-free TFLite exports.
+- Default model recommendation is updated only after measured FPS and detection stability are compared across candidate resolutions.


### PR DESCRIPTION
## Summary
- add a `VIA_GPU model_io` setup log with model/backend/input/output/layout metadata
- expose the YOLO parser layout name for log/test reuse
- document the YOLO26n 640 FPS investigation and flatbuffer evidence

## Evidence
- Previous YOLO11n 7cls v2 640 float16 export: raw output `[1, 11, 8400]`
- Delivered YOLO26n 7cls v2 640 float16 export: post-processed output `[1, 300, 6]`
- YOLO26n graph includes NMS-like tail operators such as `TOPK_V2`, so runtime FPS must be measured as an export/delegate property, not inferred from file size alone.

## Validation
- `./gradlew testDebugUnitTest --tests 'kr.co.gachon.pproject6.via.ml.YoloOutputParserTest'`
- `./gradlew testDebugUnitTest`
- `./gradlew lintDebug`
- `./gradlew assembleDebug`

## Not tested
- On-device camera FPS retest; app install was intentionally skipped while the device is unavailable.

Refs #58
