### PR TITLE
fix(perf): prefer realtime YOLO26n startup profile

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -204,6 +204,7 @@ class MainActivity : AppCompatActivity() {
     // Performance Tracker
     private val performanceTracker = PerformanceTracker()
     private val cameraRateTracker = RateTracker(label = "Camera FPS")
+    private var lastPerformanceLogAtElapsedMs = 0L
     private val pendingFrame = AtomicReference<ImageProxy?>(null)
     private val processingScheduled = AtomicBoolean(false)
     private val imageProxyTransformFactory =
@@ -465,8 +466,11 @@ class MainActivity : AppCompatActivity() {
         val shouldUseSavedBackend =
             initialBackendPreference?.contains("GPU") == true &&
                 currentModelProfile.recommendedUseGpu
+        val shouldUseRecommendedBackend =
+            initialBackendPreference == null &&
+                currentModelProfile.recommendedUseGpu
         configureGpuSwitch(
-            checked = shouldUseSavedBackend || currentModelProfile.recommendedUseGpu,
+            checked = shouldUseSavedBackend || shouldUseRecommendedBackend,
             enabled = currentModelProfile.recommendedUseGpu
         )
         publishBackendStatus("Initializing…")
@@ -757,6 +761,26 @@ class MainActivity : AppCompatActivity() {
         avgFpsText.text = performanceTracker.avgFpsStr.replaceFirst("Avg FPS", "Processed Avg FPS")
         avgLatencyText.text = performanceTracker.avgLatencyStr
         stageBreakdownText.text = performanceTracker.stageBreakdownStr
+        logPerformanceSnapshotIfDue(totalLatencyMs)
+    }
+
+    private fun logPerformanceSnapshotIfDue(totalLatencyMs: Long) {
+        val now = SystemClock.elapsedRealtime()
+        if (now - lastPerformanceLogAtElapsedMs < 1_000L) {
+            return
+        }
+        lastPerformanceLogAtElapsedMs = now
+
+        Log.i(
+            "VIA_PERF",
+            "model=$currentModelName backend=${detector?.runtimeBackendLabel ?: "unknown"} " +
+                "analysis=${currentModelProfile.analysisResolution.width}x" +
+                "${currentModelProfile.analysisResolution.height} " +
+                "input=\"${inputFpsText.text}\" processed=\"${fpsText.text}\" " +
+                "processedAvg=\"${avgFpsText.text}\" detect=\"${latencyText.text}\" " +
+                "avg=\"${avgLatencyText.text}\" total=${totalLatencyMs}ms " +
+                "stages=\"${stageBreakdownText.text}\""
+        )
     }
 
     private fun initDetector(

--- a/app/src/main/java/kr/co/gachon/pproject6/via/ml/InferenceModelProfile.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/ml/InferenceModelProfile.kt
@@ -57,6 +57,10 @@ data class InferenceModelProfile(
             profile: InferenceModelProfile,
             gpuSupported: Boolean
         ): Int {
+            if (isYolo26nNmsExport(profile.fileName)) {
+                return yolo26nNmsExportPreferenceRank(profile)
+            }
+
             val quantizationRank = when (profile.quantization) {
                 ModelQuantization.FLOAT16 -> 0
                 ModelQuantization.FLOAT32 -> if (gpuSupported) 1 else 2
@@ -65,6 +69,27 @@ data class InferenceModelProfile(
             }
 
             val targetInput = if (profile.recommendedUseGpu) 640 else 448
+            val sizeRank = profile.inputSize?.let { kotlin.math.abs(it - targetInput) } ?: 10_000
+            return quantizationRank * 10_000 + sizeRank
+        }
+
+        private fun isYolo26nNmsExport(fileName: String): Boolean {
+            return "yolo26n_7cls_v2" in fileName.lowercase()
+        }
+
+        private fun yolo26nNmsExportPreferenceRank(profile: InferenceModelProfile): Int {
+            // The delivered YOLO26n Android TFLite files emit [1, 300, 6], which means
+            // post-processing/NMS is part of the TFLite graph. On the S25+ field path,
+            // 640/512/448/416 float16 candidates saturate the frame pipeline even though
+            // the model files are smaller than the older raw-output export. Prefer the
+            // measured realtime candidate until a NMS-free export is available.
+            val quantizationRank = when (profile.quantization) {
+                ModelQuantization.INT8 -> 0
+                ModelQuantization.FLOAT16 -> 1
+                ModelQuantization.FLOAT32 -> 2
+                ModelQuantization.UNKNOWN -> 3
+            }
+            val targetInput = 320
             val sizeRank = profile.inputSize?.let { kotlin.math.abs(it - targetInput) } ?: 10_000
             return quantizationRank * 10_000 + sizeRank
         }

--- a/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloDetector.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloDetector.kt
@@ -129,6 +129,7 @@ class YoloDetector(
     private var outputRows = 0
     private var outputCols = 0
     private var outputIsTransposed = false
+    private var outputUsesBatchedNmsLayout = false
     private var inputDataType: DataType = DataType.FLOAT32
     private var outputDataType: DataType = DataType.FLOAT32
     private var inputQuantization = Tensor.QuantizationParams(0f, 0)
@@ -182,6 +183,7 @@ class YoloDetector(
         outputIsTransposed = outputShape[1] > outputShape[2]
         outputRows = if (outputIsTransposed) outputShape[1] else outputShape[2]
         outputCols = if (outputIsTransposed) outputShape[2] else outputShape[1]
+        outputUsesBatchedNmsLayout = YoloOutputParser.usesBatchedNmsLayout(outputCols, labels)
         Log.i(
             TAG,
             "model_io model=$modelPath backend=$runtimeBackendLabel requestedGpu=$useGpu " +
@@ -219,8 +221,10 @@ class YoloDetector(
         val outputArray = outputBufferToFloatArray(activeOutputBuffer)
         val results = postProcess(outputArray, confidenceThreshold)
 
-        // Apply strict NMS first to reduce boxes
-        val nmsResults = nms(results)
+        // NMS-included TFLite exports already emit a top-k detection tensor. Running the
+        // app's class-agnostic NMS again can remove legitimate neighboring classes and
+        // adds avoidable work on the realtime path. Raw YOLO tensors still need app NMS.
+        val nmsResults = if (outputUsesBatchedNmsLayout) results else nms(results)
 
         // Return raw NMS results (no color correction inside detector)
         return DetectionResult(nmsResults, inferenceTime)

--- a/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloOutputParser.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloOutputParser.kt
@@ -15,11 +15,18 @@ data class ParsedYoloDetection(
 
 object YoloOutputParser {
     fun layoutName(outputCols: Int, labels: List<String>): String {
-        return if (isBatchedNmsLayout(outputCols, labels)) {
+        return if (usesBatchedNmsLayout(outputCols, labels)) {
             "batched_nms_xyxy_score_class"
         } else {
             "class_score_cxcywh"
         }
+    }
+
+    fun usesBatchedNmsLayout(outputCols: Int, labels: List<String>): Boolean {
+        // Ultralytics TFLite NMS exports commonly emit [x1, y1, x2, y2, score, class].
+        // Legacy/class-score outputs with two labels can also have 6 columns
+        // ([cx, cy, w, h, class0, class1]), so require more labels than score columns.
+        return outputCols == 6 && labels.size > outputCols - 4
     }
 
     fun parse(
@@ -45,7 +52,7 @@ object YoloOutputParser {
 
         for (row in 0 until outputRows) {
             val detection =
-                if (isBatchedNmsLayout(outputCols, labels)) {
+                if (usesBatchedNmsLayout(outputCols, labels)) {
                     parseBatchedNmsRow(
                         row = row,
                         get = ::get,
@@ -71,13 +78,6 @@ object YoloOutputParser {
         }
 
         return detections
-    }
-
-    private fun isBatchedNmsLayout(outputCols: Int, labels: List<String>): Boolean {
-        // Ultralytics TFLite NMS exports commonly emit [x1, y1, x2, y2, score, class].
-        // Legacy/class-score outputs with two labels can also have 6 columns
-        // ([cx, cy, w, h, class0, class1]), so require more labels than score columns.
-        return outputCols == 6 && labels.size > outputCols - 4
     }
 
     private fun parseBatchedNmsRow(

--- a/app/src/test/java/kr/co/gachon/pproject6/via/ml/InferenceModelProfileTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/ml/InferenceModelProfileTest.kt
@@ -38,7 +38,7 @@ class InferenceModelProfileTest {
     }
 
     @Test
-    fun recommendPrefersBalancedGpuProfileWhenGpuIsAvailable() {
+    fun recommendPrefersMeasuredRealtimeYolo26nProfileWhenGpuIsAvailable() {
         val profile = InferenceModelProfile.recommend(
             modelFiles = listOf(
                 "best_yolo26n_7cls_v2_float16_640.tflite",
@@ -50,11 +50,41 @@ class InferenceModelProfileTest {
         )
 
         assertNotNull(profile)
-        assertEquals("best_yolo26n_7cls_v2_float16_640.tflite", profile?.fileName)
+        assertEquals("best_yolo26n_7cls_v2_int8_320.tflite", profile?.fileName)
     }
 
     @Test
-    fun recommendStillStartsFromFloatProfileWhenGpuCompatibilityIsUnavailable() {
+    fun recommendFallsBackToFloat16Yolo26n320WhenInt8RealtimeProfileIsMissing() {
+        val profile = InferenceModelProfile.recommend(
+            modelFiles = listOf(
+                "best_yolo26n_7cls_v2_float16_640.tflite",
+                "best_yolo26n_7cls_v2_float16_320.tflite",
+                "best_yolo26n_7cls_v2_float16_416.tflite"
+            ),
+            gpuSupported = true
+        )
+
+        assertNotNull(profile)
+        assertEquals("best_yolo26n_7cls_v2_float16_320.tflite", profile?.fileName)
+    }
+
+    @Test
+    fun legacyRecommendationStillTargetsHighResolutionFloatWhenGpuIsAvailable() {
+        val profile = InferenceModelProfile.recommend(
+            modelFiles = listOf(
+                "best_float16_640.tflite",
+                "best_float16_416.tflite",
+                "best_int8_320.tflite"
+            ),
+            gpuSupported = true
+        )
+
+        assertNotNull(profile)
+        assertEquals("best_float16_640.tflite", profile?.fileName)
+    }
+
+    @Test
+    fun yolo26nRealtimeRecommendationDoesNotDependOnGpuCompatibility() {
         val profile = InferenceModelProfile.recommend(
             modelFiles = listOf(
                 "best_yolo26n_7cls_v2_float16_640.tflite",
@@ -66,6 +96,6 @@ class InferenceModelProfileTest {
         )
 
         assertNotNull(profile)
-        assertEquals("best_yolo26n_7cls_v2_float16_640.tflite", profile?.fileName)
+        assertEquals("best_yolo26n_7cls_v2_int8_320.tflite", profile?.fileName)
     }
 }

--- a/app/src/test/java/kr/co/gachon/pproject6/via/ml/YoloOutputParserTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/ml/YoloOutputParserTest.kt
@@ -7,6 +7,12 @@ import org.junit.Test
 class YoloOutputParserTest {
     @Test
     fun layoutNameDescribesYolo26nBatchedNmsOutput() {
+        assertTrue(
+            YoloOutputParser.usesBatchedNmsLayout(
+                outputCols = 6,
+                labels = DetectionLabels.sevenClassLabels
+            )
+        )
         assertEquals(
             "batched_nms_xyxy_score_class",
             YoloOutputParser.layoutName(
@@ -18,6 +24,12 @@ class YoloOutputParserTest {
 
     @Test
     fun layoutNameKeepsSixColumnTwoClassOutputAsClassScore() {
+        assertTrue(
+            !YoloOutputParser.usesBatchedNmsLayout(
+                outputCols = 6,
+                labels = listOf(DetectionLabels.HUMAN_RED, DetectionLabels.HUMAN_GREEN)
+            )
+        )
         assertEquals(
             "class_score_cxcywh",
             YoloOutputParser.layoutName(

--- a/resources/validation/yolo26n-runtime-fps-investigation-2026-05-14.md
+++ b/resources/validation/yolo26n-runtime-fps-investigation-2026-05-14.md
@@ -65,14 +65,33 @@ layout=batched_nms_xyxy_score_class labels=7 output=[1, 300, 6]
 
 A raw YOLO export should instead show a class-score layout such as `layout=class_score_cxcywh` with columns equal to `4 + classCount` after normalization.
 
+## S25+ realtime retest — 2026-05-15
+After adding `VIA_PERF` logging, the installed debug build was tested with the delivered YOLO26n exports. The camera was running live, GPU was used for float16 profiles, and int8 profiles used CPU. Results below use the stable samples after warmup.
+
+| Model | Backend | Analysis | Processed FPS | Avg latency | Detect stage |
+| --- | --- | --- | ---: | ---: | ---: |
+| `best_yolo26n_7cls_v2_float16_640.tflite` | GPU | 960x720 | 4.87 | 204ms | ~204ms |
+| `best_yolo26n_7cls_v2_float16_512.tflite` | GPU | 768x576 | 7.45 | 130ms | ~130ms |
+| `best_yolo26n_7cls_v2_float16_448.tflite` | GPU | 640x480 | 9.61 | 99ms | ~99ms |
+| `best_yolo26n_7cls_v2_float16_416.tflite` | GPU | 640x480 | 10.93 | 86ms | ~86ms |
+| `best_yolo26n_7cls_v2_float16_320.tflite` | GPU | 480x360 | 16.61 | 51ms | ~51ms |
+| `best_yolo26n_7cls_v2_int8_640.tflite` | CPU | 960x720 | 6.00 | 161ms | ~162ms |
+| `best_yolo26n_7cls_v2_int8_320.tflite` | CPU | 480x360 | 20.07 | 38ms | ~38ms |
+
+Decision for this branch: prefer `best_yolo26n_7cls_v2_int8_320.tflite` as the automatic YOLO26n startup profile so the live pipeline is no longer pinned to the slow NMS-included 640 export. Keep float16 320 as the fallback if the int8 realtime profile is missing.
+
+The detector also skips the app-side class-agnostic NMS pass for NMS-included `[1, 300, 6]` exports because the model has already emitted top-k detections; raw class-score exports still use app-side NMS. Final default-retained install verified `best_yolo26n_7cls_v2_int8_320.tflite` on CPU at ~19.9 processed FPS after warmup.
+
+This is a runtime workaround, not the final model-delivery answer. The 640 float16 candidate still needs a NMS-free/raw-output export to recover high-resolution throughput.
+
 ## Retest plan
 1. Run the same realtime route with YOLO26n float16 320/416/448/512/640.
 2. Record Camera FPS, Processed FPS, latency, model name, backend, analysis resolution, and the new `model_io` log line.
 3. Compare YOLO26n NMS-included 640 against a future NMS-free YOLO26n 640 export if available.
-4. Keep the 320 candidate as a temporary field-test workaround only; do not permanently lower the default until the export/runtime cause is decided.
+4. Treat the 320 int8 candidate as the current realtime default until a NMS-free high-resolution export proves it can restore throughput.
 5. If NMS-free YOLO26n restores expected throughput, prefer raw-output export plus app-side NMS for Android delivery.
 
 ## Acceptance criteria for closing #58
 - The 640 FPS regression is attributed to either export layout/delegate compatibility, analysis resolution cost, or model compute cost with evidence.
 - The team decides whether Android should use NMS-included or NMS-free TFLite exports.
-- Default model recommendation is updated only after measured FPS and detection stability are compared across candidate resolutions.
+- Default model recommendation is backed by measured FPS and can be revised when a NMS-free high-resolution export is available.


### PR DESCRIPTION
## Summary
- prefer the measured YOLO26n realtime profile (`best_yolo26n_7cls_v2_int8_320.tflite`, CPU) for automatic startup
- add `VIA_PERF` live FPS/latency/stage logging for field checks
- skip the app-side NMS pass when the TFLite model already emits `[1, 300, 6]` NMS/top-k detections
- respect a persisted CPU backend preference instead of forcing GPU for float profiles

## Device evidence
Stable live-camera samples after warmup:

| Model | Backend | Analysis | Processed FPS | Avg latency |
| --- | --- | --- | ---: | ---: |
| YOLO26n float16 640 | GPU | 960x720 | 4.87 | 204ms |
| YOLO26n float16 512 | GPU | 768x576 | 7.45 | 130ms |
| YOLO26n float16 448 | GPU | 640x480 | 9.61 | 99ms |
| YOLO26n float16 416 | GPU | 640x480 | 10.93 | 86ms |
| YOLO26n float16 320 | GPU | 480x360 | 16.61 | 51ms |
| YOLO26n int8 640 | CPU | 960x720 | 6.00 | 161ms |
| YOLO26n int8 320 | CPU | 480x360 | 20.07 | 38ms |

Final installed build with the new default selected `best_yolo26n_7cls_v2_int8_320.tflite` on CPU and measured ~19.9 processed FPS after warmup.

## Validation
- `./gradlew testDebugUnitTest --tests 'kr.co.gachon.pproject6.via.ml.YoloOutputParserTest' --tests 'kr.co.gachon.pproject6.via.ml.InferenceModelProfileTest'`
- `./gradlew testDebugUnitTest`
- `./gradlew lintDebug`
- `./gradlew assembleDebug`
- Debug APK installed and launched; `VIA_GPU model_io` + `VIA_PERF` verified the new default.

## Follow-up
The 640 profile is still not considered fixed. It likely needs a NMS-free/raw-output YOLO26n TFLite export to recover high-resolution throughput.

Refs #58
