### PR TITLE
fix: cap camera input fps at 20

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicy.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicy.kt
@@ -14,6 +14,9 @@ data class CameraFlickerMitigationSettings(
 }
 
 object CameraFlickerMitigationPolicy {
+    private const val DEFAULT_MAX_INPUT_FPS = 20
+    private const val SAFE_FALLBACK_MAX_INPUT_FPS = 30
+
     fun chooseAntibandingMode(
         availableModes: IntArray?,
         preferredMode: Int,
@@ -32,12 +35,30 @@ object CameraFlickerMitigationPolicy {
         }
     }
 
-    fun chooseTargetFpsRange(availableRanges: List<CameraFpsRange>): CameraFpsRange? {
+    fun chooseTargetFpsRange(
+        availableRanges: List<CameraFpsRange>,
+        maxInputFps: Int = DEFAULT_MAX_INPUT_FPS
+    ): CameraFpsRange? {
+        val cappedRanges =
+            availableRanges
+                .filter { it.upper <= maxInputFps }
+                .sortedWith(
+                    compareByDescending<CameraFpsRange> { it.upper }
+                        .thenByDescending { it.lower }
+                )
+
+        if (cappedRanges.isNotEmpty()) {
+            return cappedRanges.first()
+        }
+
+        // Some Camera2 HALs do not expose an exact <=20 FPS range. In that case,
+        // prefer a variable low-start range such as 15-30 instead of forcing 30-30,
+        // so AE can still settle below 30 when the device supports it.
         return availableRanges
-            .filter { it.upper <= 30 }
+            .filter { it.lower <= maxInputFps && it.upper <= SAFE_FALLBACK_MAX_INPUT_FPS }
             .sortedWith(
-                compareByDescending<CameraFpsRange> { it.upper }
-                    .thenByDescending { it.lower }
+                compareBy<CameraFpsRange> { it.upper }
+                    .thenBy { it.lower }
             )
             .firstOrNull()
     }

--- a/app/src/test/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicyTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicyTest.kt
@@ -45,41 +45,57 @@ class CameraFlickerMitigationPolicyTest {
     }
 
     @Test
-    fun targetFpsRangePrefersStableThirtyFpsCap() {
+    fun targetFpsRangePrefersExactTwentyFpsCap() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
                     CameraFpsRange(15, 60),
                     CameraFpsRange(15, 30),
                     CameraFpsRange(30, 30),
-                    CameraFpsRange(24, 30)
+                    CameraFpsRange(20, 20),
+                    CameraFpsRange(15, 20)
                 )
             )
 
-        assertEquals(CameraFpsRange(30, 30), chosen)
+        assertEquals(CameraFpsRange(20, 20), chosen)
     }
 
     @Test
-    fun targetFpsRangeFallsBackToHighestRangeCappedAtThirty() {
+    fun targetFpsRangeUsesHighestRangeCappedAtTwenty() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
                     CameraFpsRange(15, 60),
                     CameraFpsRange(15, 30),
-                    CameraFpsRange(24, 30),
+                    CameraFpsRange(10, 20),
                     CameraFpsRange(15, 15)
                 )
             )
 
-        assertEquals(CameraFpsRange(24, 30), chosen)
+        assertEquals(CameraFpsRange(10, 20), chosen)
     }
 
     @Test
-    fun targetFpsRangeDoesNotChooseSixtyFpsRanges() {
+    fun targetFpsRangeFallsBackToLowStartThirtyRangeWhenTwentyUnavailable() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
                     CameraFpsRange(15, 60),
+                    CameraFpsRange(30, 30),
+                    CameraFpsRange(24, 30),
+                    CameraFpsRange(15, 30)
+                )
+            )
+
+        assertEquals(CameraFpsRange(15, 30), chosen)
+    }
+
+    @Test
+    fun targetFpsRangeDoesNotForceFixedThirtyWhenNoLowStartRangeExists() {
+        val chosen =
+            CameraFlickerMitigationPolicy.chooseTargetFpsRange(
+                listOf(
+                    CameraFpsRange(30, 30),
                     CameraFpsRange(30, 60),
                     CameraFpsRange(60, 60)
                 )


### PR DESCRIPTION
## Summary
- changes Camera2 target FPS range selection to prefer supported ranges capped at 20 FPS
- avoids explicitly forcing fixed 30 FPS when a lower-start fallback range is available
- keeps antibanding/flicker mitigation behavior unchanged

## Validation
- ./gradlew testDebugUnitTest --tests 'kr.co.gachon.pproject6.via.camera.CameraFlickerMitigationPolicyTest'
- ./gradlew testDebugUnitTest lintDebug assembleDebug
- adb install -r on connected debug devices

## Notes
- This is a stacked PR on #62 because the Camera2 flicker-mitigation policy lives on that branch.
- If a device camera HAL does not expose a <=20 FPS target range, Android can only receive the best supported fallback range; the debug Camera FPS metric should continue to show the real callback rate.

Fixes #64