### PR TITLE
fix: align demo fps target at 15

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/MainActivity.kt
@@ -86,7 +86,7 @@ class MainActivity : AppCompatActivity() {
     private companion object {
         private const val CAMERA_COLD_START_TIMEOUT_MS = 3_500L
         private const val MAX_CAMERA_COLD_START_RECOVERIES = 1
-        private const val DEFAULT_MAX_PROCESSED_FPS = 20.0
+        private const val DEFAULT_MAX_PROCESSED_FPS = 15.0
         private const val MIN_MAX_PROCESSED_FPS = 10.0
         private const val MAX_MAX_PROCESSED_FPS = 30.0
         private const val VIDEO_REPLAY_CAPTURE_TIMEOUT_MS = 250L

--- a/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicy.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicy.kt
@@ -14,7 +14,7 @@ data class CameraFlickerMitigationSettings(
 }
 
 object CameraFlickerMitigationPolicy {
-    private const val DEFAULT_TARGET_INPUT_FPS = 20
+    private const val DEFAULT_TARGET_INPUT_FPS = 15
     private const val SAFE_FALLBACK_MAX_INPUT_FPS = 30
 
     fun chooseAntibandingMode(
@@ -43,10 +43,9 @@ object CameraFlickerMitigationPolicy {
             .firstOrNull { it.lower == targetInputFps && it.upper == targetInputFps }
             ?.let { return it }
 
-        // S25-class Camera2 HALs may expose 15-20 but no exact 20-20. Requesting
-        // 15-20 lets AE settle at 15 FPS, which is too low for guidance. Prefer a
-        // nearby fixed range such as 24-24, then keep processed inference capped at
-        // 20 FPS separately for the thermal/battery budget.
+        // Prefer an exact low fixed input rate for thermal/battery stability.
+        // If a camera HAL lacks exact 15 FPS, use the nearest fixed range above it
+        // rather than a wide variable range whose actual cadence can be unstable.
         val nearbyFixedRange =
             availableRanges
                 .filter {

--- a/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicy.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicy.kt
@@ -14,7 +14,7 @@ data class CameraFlickerMitigationSettings(
 }
 
 object CameraFlickerMitigationPolicy {
-    private const val DEFAULT_MAX_INPUT_FPS = 20
+    private const val DEFAULT_TARGET_INPUT_FPS = 20
     private const val SAFE_FALLBACK_MAX_INPUT_FPS = 30
 
     fun chooseAntibandingMode(
@@ -37,28 +37,37 @@ object CameraFlickerMitigationPolicy {
 
     fun chooseTargetFpsRange(
         availableRanges: List<CameraFpsRange>,
-        maxInputFps: Int = DEFAULT_MAX_INPUT_FPS
+        targetInputFps: Int = DEFAULT_TARGET_INPUT_FPS
     ): CameraFpsRange? {
-        val cappedRanges =
+        availableRanges
+            .firstOrNull { it.lower == targetInputFps && it.upper == targetInputFps }
+            ?.let { return it }
+
+        // S25-class Camera2 HALs may expose 15-20 but no exact 20-20. Requesting
+        // 15-20 lets AE settle at 15 FPS, which is too low for guidance. Prefer a
+        // nearby fixed range such as 24-24, then keep processed inference capped at
+        // 20 FPS separately for the thermal/battery budget.
+        val nearbyFixedRange =
             availableRanges
-                .filter { it.upper <= maxInputFps }
-                .sortedWith(
-                    compareByDescending<CameraFpsRange> { it.upper }
-                        .thenByDescending { it.lower }
+                .filter {
+                    it.lower == it.upper &&
+                        it.upper > targetInputFps &&
+                        it.upper <= SAFE_FALLBACK_MAX_INPUT_FPS
+                }
+                .minWithOrNull(
+                    compareBy<CameraFpsRange> { it.upper - targetInputFps }
+                        .thenBy { it.upper }
                 )
 
-        if (cappedRanges.isNotEmpty()) {
-            return cappedRanges.first()
+        if (nearbyFixedRange != null) {
+            return nearbyFixedRange
         }
 
-        // Some Camera2 HALs do not expose an exact <=20 FPS range. In that case,
-        // prefer a variable low-start range such as 15-30 instead of forcing 30-30,
-        // so AE can still settle below 30 when the device supports it.
         return availableRanges
-            .filter { it.lower <= maxInputFps && it.upper <= SAFE_FALLBACK_MAX_INPUT_FPS }
+            .filter { it.lower <= targetInputFps && it.upper <= SAFE_FALLBACK_MAX_INPUT_FPS }
             .sortedWith(
-                compareBy<CameraFpsRange> { it.upper }
-                    .thenBy { it.lower }
+                compareByDescending<CameraFpsRange> { it.upper }
+                    .thenByDescending { it.lower }
             )
             .firstOrNull()
     }

--- a/app/src/main/java/kr/co/gachon/pproject6/via/onboarding/CalibrationSelector.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/onboarding/CalibrationSelector.kt
@@ -3,7 +3,7 @@ package kr.co.gachon.pproject6.via.onboarding
 import kr.co.gachon.pproject6.via.ml.InferenceModelProfile
 import kr.co.gachon.pproject6.via.ml.ModelQuantization
 
-private const val CALIBRATION_TARGET_FPS = 20.0
+private const val CALIBRATION_TARGET_FPS = 15.0
 
 data class CalibrationProfileResult(
     val profile: InferenceModelProfile,

--- a/app/src/test/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicyTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicyTest.kt
@@ -45,7 +45,7 @@ class CameraFlickerMitigationPolicyTest {
     }
 
     @Test
-    fun targetFpsRangePrefersExactTwentyFpsWhenAvailable() {
+    fun targetFpsRangePrefersExactFifteenFpsWhenAvailable() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
@@ -53,15 +53,16 @@ class CameraFlickerMitigationPolicyTest {
                     CameraFpsRange(15, 30),
                     CameraFpsRange(30, 30),
                     CameraFpsRange(20, 20),
+                    CameraFpsRange(15, 15),
                     CameraFpsRange(15, 20)
                 )
             )
 
-        assertEquals(CameraFpsRange(20, 20), chosen)
+        assertEquals(CameraFpsRange(15, 15), chosen)
     }
 
     @Test
-    fun targetFpsRangePrefersNearbyFixedRangeOverVariableFifteenToTwenty() {
+    fun targetFpsRangeUsesNearestFixedFpsWhenFifteenIsUnavailable() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
@@ -69,8 +70,7 @@ class CameraFlickerMitigationPolicyTest {
                     CameraFpsRange(15, 30),
                     CameraFpsRange(30, 30),
                     CameraFpsRange(24, 24),
-                    CameraFpsRange(15, 20),
-                    CameraFpsRange(15, 15)
+                    CameraFpsRange(15, 20)
                 )
             )
 
@@ -78,14 +78,14 @@ class CameraFlickerMitigationPolicyTest {
     }
 
     @Test
-    fun targetFpsRangeFallsBackToBestVariableRangeWhenNoNearbyFixedRangeExists() {
+    fun targetFpsRangeFallsBackToBestVariableRangeWhenNoFixedRangeExists() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
                     CameraFpsRange(15, 60),
                     CameraFpsRange(15, 30),
-                    CameraFpsRange(15, 20),
-                    CameraFpsRange(15, 15)
+                    CameraFpsRange(10, 15),
+                    CameraFpsRange(10, 10)
                 )
             )
 

--- a/app/src/test/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicyTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/camera/CameraFlickerMitigationPolicyTest.kt
@@ -45,7 +45,7 @@ class CameraFlickerMitigationPolicyTest {
     }
 
     @Test
-    fun targetFpsRangePrefersExactTwentyFpsCap() {
+    fun targetFpsRangePrefersExactTwentyFpsWhenAvailable() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
@@ -61,29 +61,31 @@ class CameraFlickerMitigationPolicyTest {
     }
 
     @Test
-    fun targetFpsRangeUsesHighestRangeCappedAtTwenty() {
+    fun targetFpsRangePrefersNearbyFixedRangeOverVariableFifteenToTwenty() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
                     CameraFpsRange(15, 60),
                     CameraFpsRange(15, 30),
-                    CameraFpsRange(10, 20),
+                    CameraFpsRange(30, 30),
+                    CameraFpsRange(24, 24),
+                    CameraFpsRange(15, 20),
                     CameraFpsRange(15, 15)
                 )
             )
 
-        assertEquals(CameraFpsRange(10, 20), chosen)
+        assertEquals(CameraFpsRange(24, 24), chosen)
     }
 
     @Test
-    fun targetFpsRangeFallsBackToLowStartThirtyRangeWhenTwentyUnavailable() {
+    fun targetFpsRangeFallsBackToBestVariableRangeWhenNoNearbyFixedRangeExists() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
                     CameraFpsRange(15, 60),
-                    CameraFpsRange(30, 30),
-                    CameraFpsRange(24, 30),
-                    CameraFpsRange(15, 30)
+                    CameraFpsRange(15, 30),
+                    CameraFpsRange(15, 20),
+                    CameraFpsRange(15, 15)
                 )
             )
 
@@ -91,11 +93,10 @@ class CameraFlickerMitigationPolicyTest {
     }
 
     @Test
-    fun targetFpsRangeDoesNotForceFixedThirtyWhenNoLowStartRangeExists() {
+    fun targetFpsRangeDoesNotForceFixedThirtyWhenNoUsableFallbackExists() {
         val chosen =
             CameraFlickerMitigationPolicy.chooseTargetFpsRange(
                 listOf(
-                    CameraFpsRange(30, 30),
                     CameraFpsRange(30, 60),
                     CameraFpsRange(60, 60)
                 )

--- a/app/src/test/java/kr/co/gachon/pproject6/via/onboarding/CalibrationSelectorTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/onboarding/CalibrationSelectorTest.kt
@@ -21,10 +21,10 @@ class CalibrationSelectorTest {
     }
 
     @Test
-    fun chooseBestPicksHighestResolutionMeetingTwentyFpsTarget() {
+    fun chooseBestPicksHighestResolutionMeetingFifteenFpsTarget() {
         val low = result("best_yolo26n_7cls_v2_float16_448.tflite", 31.0)
         val mid = result("best_yolo26n_7cls_v2_float16_512.tflite", 30.1)
-        val high = result("best_yolo26n_7cls_v2_float16_640.tflite", 20.0)
+        val high = result("best_yolo26n_7cls_v2_float16_640.tflite", 15.0)
 
         val best = CalibrationSelector.chooseBest(listOf(low, mid, high))
 
@@ -34,8 +34,8 @@ class CalibrationSelectorTest {
 
     @Test
     fun chooseBestFallsBackToFastestWhenNothingMeetsTarget() {
-        val faster = result("best_yolo26n_7cls_v2_float16_512.tflite", 19.0)
-        val slower = result("best_yolo26n_7cls_v2_float16_640.tflite", 18.0)
+        val faster = result("best_yolo26n_7cls_v2_float16_512.tflite", 14.0)
+        val slower = result("best_yolo26n_7cls_v2_float16_640.tflite", 13.0)
 
         val best = CalibrationSelector.chooseBest(listOf(slower, faster))
 
@@ -47,7 +47,7 @@ class CalibrationSelectorTest {
         return CalibrationProfileResult(
             profile = InferenceModelProfile.fromFileName(fileName),
             backendLabel = "GPU",
-            averageInputFps = 30.0,
+            averageInputFps = 15.0,
             averageDetectFps = fps,
             averageDetectLatencyMs = 0L,
             averageTotalLatencyMs = 0L,

--- a/resources/validation/yolo26n-raw-output-adoption-2026-05-15.md
+++ b/resources/validation/yolo26n-raw-output-adoption-2026-05-15.md
@@ -100,3 +100,12 @@ This confirms the input label is no longer a proxy for inference throughput. The
 - `./gradlew assembleDebug` ✅
 - Debug APK install and live-camera log capture ✅
 - Debug APK reinstall after input-FPS label fix; live-camera logs show Camera FPS ~30 while Processed FPS ~9..10 ✅
+
+## 15fps thermal-stability policy update — 2026-05-24
+S25+ field testing after the 24fps camera-input fallback showed that camera input held near 24fps, but sustained raw 640 float16/GPU processing dropped to roughly 11.6..12.0 Processed FPS as device temperature rose. To reduce oscillation and make onboarding recommendations match the demo operating point, the runtime policy is updated to prefer exact 15fps camera input when the HAL exposes it, set the default Max Processed FPS to 15, and lower onboarding calibration's pass target to 15fps.
+
+Policy after this update:
+- Live Camera2 target range prefers exact `15-15` for thermal/battery stability.
+- If exact 15fps is unavailable, the app can fall back to the nearest fixed range above 15 rather than a wide variable range.
+- Onboarding calibration target is 15fps, so model selection is evaluated against the same sustained demo target.
+- Debug Camera FPS remains the real callback rate; no synthetic FPS label is used.


### PR DESCRIPTION
## Summary
- prefers exact `15-15` Camera2 target FPS for the demo stability path
- lowers default Max Processed FPS to 15 so live/replay pacing matches the thermal target
- lowers onboarding calibration pass target to 15 FPS so startup model selection matches the actual demo budget
- documents the S25+ 24fps test result and the move back to 15fps for stability

## Validation
- ./gradlew testDebugUnitTest --tests 'kr.co.gachon.pproject6.via.camera.CameraFlickerMitigationPolicyTest' --tests 'kr.co.gachon.pproject6.via.onboarding.CalibrationSelectorTest'
- ./gradlew testDebugUnitTest lintDebug assembleDebug

## Notes
- 24fps camera input was applied successfully, but raw 640/GPU processing settled around 11.6..12fps under thermal load.
- This PR chooses a stable 15fps demo operating point rather than pushing camera input higher than sustained processing can handle.
- Camera FPS remains the real camera callback rate, not a synthetic capped value.

Fixes #68
Refs #53
Refs #64
Supersedes #66