### PR TITLE
fix(ml): center crop YOLO input

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/ml/SquareCropTransform.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/ml/SquareCropTransform.kt
@@ -1,0 +1,99 @@
+package kr.co.gachon.pproject6.via.ml
+
+import android.graphics.Rect
+import android.graphics.RectF
+import kotlin.math.min
+
+/**
+ * Keeps YOLO's square tensor input without shrinking the central scene.
+ *
+ * The camera/replay frame can be rectangular, but the model expects a square image.
+ * Letterbox preserves the full frame but makes small signal lights smaller. For this
+ * demo path, we center-crop the longer axis and resize the square crop to the model
+ * input. Detector outputs are then mapped back to the original source bitmap space.
+ */
+data class SquareCropTransform(
+    val sourceWidth: Int,
+    val sourceHeight: Int,
+    val inputWidth: Int,
+    val inputHeight: Int,
+    val cropLeft: Int,
+    val cropTop: Int,
+    val cropSize: Int
+) {
+    val sourceRect: Rect = Rect(cropLeft, cropTop, cropLeft + cropSize, cropTop + cropSize)
+    val destinationRect: RectF = RectF(0f, 0f, inputWidth.toFloat(), inputHeight.toFloat())
+
+    fun inputRectToSourceNormalized(inputNormalizedRect: RectF): RectF? {
+        return inputBoundsToSourceNormalized(
+            left = inputNormalizedRect.left,
+            top = inputNormalizedRect.top,
+            right = inputNormalizedRect.right,
+            bottom = inputNormalizedRect.bottom
+        )?.toRectF()
+    }
+
+    internal fun inputBoundsToSourceNormalized(
+        left: Float,
+        top: Float,
+        right: Float,
+        bottom: Float
+    ): NormalizedBox? {
+        if (sourceWidth <= 0 || sourceHeight <= 0 || inputWidth <= 0 || inputHeight <= 0 || cropSize <= 0) {
+            return null
+        }
+
+        val sourceLeft = cropLeft + (left * cropSize)
+        val sourceTop = cropTop + (top * cropSize)
+        val sourceRight = cropLeft + (right * cropSize)
+        val sourceBottom = cropTop + (bottom * cropSize)
+
+        val mappedLeft = (sourceLeft / sourceWidth).coerceIn(0f, 1f)
+        val mappedTop = (sourceTop / sourceHeight).coerceIn(0f, 1f)
+        val mappedRight = (sourceRight / sourceWidth).coerceIn(0f, 1f)
+        val mappedBottom = (sourceBottom / sourceHeight).coerceIn(0f, 1f)
+
+        if (mappedRight <= mappedLeft || mappedBottom <= mappedTop) {
+            return null
+        }
+
+        return NormalizedBox(mappedLeft, mappedTop, mappedRight, mappedBottom)
+    }
+
+    companion object {
+        fun from(
+            sourceWidth: Int,
+            sourceHeight: Int,
+            inputWidth: Int,
+            inputHeight: Int
+        ): SquareCropTransform {
+            require(sourceWidth > 0) { "sourceWidth must be positive" }
+            require(sourceHeight > 0) { "sourceHeight must be positive" }
+            require(inputWidth > 0) { "inputWidth must be positive" }
+            require(inputHeight > 0) { "inputHeight must be positive" }
+
+            val cropSize = min(sourceWidth, sourceHeight)
+            val cropLeft = (sourceWidth - cropSize) / 2
+            val cropTop = (sourceHeight - cropSize) / 2
+
+            return SquareCropTransform(
+                sourceWidth = sourceWidth,
+                sourceHeight = sourceHeight,
+                inputWidth = inputWidth,
+                inputHeight = inputHeight,
+                cropLeft = cropLeft,
+                cropTop = cropTop,
+                cropSize = cropSize
+            )
+        }
+    }
+}
+
+data class NormalizedBox(
+    val left: Float,
+    val top: Float,
+    val right: Float,
+    val bottom: Float
+) {
+    fun toRectF(): RectF = RectF(left, top, right, bottom)
+}

--- a/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloDetector.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/ml/YoloDetector.kt
@@ -3,7 +3,7 @@ package kr.co.gachon.pproject6.via.ml
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
-import android.graphics.Rect
+import android.graphics.Paint
 import android.graphics.RectF
 import android.os.SystemClock
 import android.util.Log
@@ -137,6 +137,7 @@ class YoloDetector(
     private var outputBuffer: ByteBuffer? = null
     private var scaledBitmapBuffer: Bitmap? = null
     private var pixelBuffer: IntArray = intArrayOf()
+    private val resizePaint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
     var runtimeBackendLabel: String = "CPU"
         private set
     var compatibilityReportedSupported: Boolean = false
@@ -207,7 +208,7 @@ class YoloDetector(
 
         val inferenceStartTime = SystemClock.uptimeMillis()
 
-        fillInputBuffer(bitmap, activeInputBuffer)
+        val squareCropTransform = fillInputBuffer(bitmap, activeInputBuffer)
         activeOutputBuffer.rewind()
 
         // Run inference
@@ -217,7 +218,7 @@ class YoloDetector(
 
         // Post-process
         val outputArray = outputBufferToFloatArray(activeOutputBuffer)
-        val results = postProcess(outputArray, confidenceThreshold)
+        val results = postProcess(outputArray, confidenceThreshold, squareCropTransform)
 
         // Apply strict NMS first to reduce boxes
         val nmsResults = nms(results)
@@ -237,8 +238,15 @@ class YoloDetector(
         }
     }
 
-    private fun fillInputBuffer(bitmap: Bitmap, buffer: ByteBuffer) {
+    private fun fillInputBuffer(bitmap: Bitmap, buffer: ByteBuffer): SquareCropTransform {
         buffer.rewind()
+        val squareCropTransform =
+            SquareCropTransform.from(
+                sourceWidth = bitmap.width,
+                sourceHeight = bitmap.height,
+                inputWidth = inputImageWidth,
+                inputHeight = inputImageHeight
+            )
         val scaledBitmap =
             if (bitmap.width == inputImageWidth && bitmap.height == inputImageHeight) {
                 bitmap
@@ -253,12 +261,14 @@ class YoloDetector(
                         inputImageHeight,
                         Bitmap.Config.ARGB_8888
                     ).also { scaledBitmapBuffer = it }
-                Canvas(reusable).drawBitmap(
-                    bitmap,
-                    null,
-                    Rect(0, 0, inputImageWidth, inputImageHeight),
-                    null
-                )
+                Canvas(reusable).apply {
+                    drawBitmap(
+                        bitmap,
+                        squareCropTransform.sourceRect,
+                        squareCropTransform.destinationRect,
+                        resizePaint
+                    )
+                }
                 reusable
             }
         scaledBitmapBuffer?.let { previous ->
@@ -291,6 +301,7 @@ class YoloDetector(
             putInputChannel(buffer, blue)
         }
         buffer.rewind()
+        return squareCropTransform
     }
 
     private fun putInputChannel(buffer: ByteBuffer, value: Int) {
@@ -336,7 +347,11 @@ class YoloDetector(
         return output
     }
 
-    private fun postProcess(output: FloatArray, threshold: Float): List<OverlayView.BoundingBox> {
+    private fun postProcess(
+        output: FloatArray,
+        threshold: Float,
+        squareCropTransform: SquareCropTransform
+    ): List<OverlayView.BoundingBox> {
         return YoloOutputParser.parse(
             output = output,
             outputRows = outputRows,
@@ -347,12 +362,16 @@ class YoloDetector(
             labels = labels,
             threshold = threshold,
             specificConfidenceThresholds = specificConfidenceThresholds
-        ).map { detection ->
-            OverlayView.BoundingBox(
-                box = RectF(detection.left, detection.top, detection.right, detection.bottom),
-                clsName = detection.clsName,
-                score = detection.score
-            )
+        ).mapNotNull { detection ->
+            squareCropTransform.inputRectToSourceNormalized(
+                RectF(detection.left, detection.top, detection.right, detection.bottom)
+            )?.let { sourceBox ->
+                OverlayView.BoundingBox(
+                    box = sourceBox,
+                    clsName = detection.clsName,
+                    score = detection.score
+                )
+            }
         }
     }
 

--- a/app/src/test/java/kr/co/gachon/pproject6/via/ml/SquareCropTransformTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/ml/SquareCropTransformTest.kt
@@ -1,0 +1,93 @@
+package kr.co.gachon.pproject6.via.ml
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SquareCropTransformTest {
+    @Test
+    fun portraitFrameCropsTopAndBottomThenMapsBackToSourceCoordinates() {
+        val transform =
+            SquareCropTransform.from(
+                sourceWidth = 576,
+                sourceHeight = 768,
+                inputWidth = 512,
+                inputHeight = 512
+            )
+
+        assertEquals(0, transform.cropLeft)
+        assertEquals(96, transform.cropTop)
+        assertEquals(576, transform.cropSize)
+
+        val mapped =
+            transform.inputBoundsToSourceNormalized(
+                left = 0.25f,
+                top = 0.25f,
+                right = 0.75f,
+                bottom = 0.75f
+            )
+
+        requireNotNull(mapped)
+        assertEquals(0.25f, mapped.left, 0.0001f)
+        assertEquals((96f + 144f) / 768f, mapped.top, 0.0001f)
+        assertEquals(0.75f, mapped.right, 0.0001f)
+        assertEquals((96f + 432f) / 768f, mapped.bottom, 0.0001f)
+    }
+
+    @Test
+    fun landscapeFrameCropsLeftAndRightThenMapsBackToSourceCoordinates() {
+        val transform =
+            SquareCropTransform.from(
+                sourceWidth = 768,
+                sourceHeight = 576,
+                inputWidth = 512,
+                inputHeight = 512
+            )
+
+        assertEquals(96, transform.cropLeft)
+        assertEquals(0, transform.cropTop)
+        assertEquals(576, transform.cropSize)
+
+        val mapped =
+            transform.inputBoundsToSourceNormalized(
+                left = 0.25f,
+                top = 0.25f,
+                right = 0.75f,
+                bottom = 0.75f
+            )
+
+        requireNotNull(mapped)
+        assertEquals((96f + 144f) / 768f, mapped.left, 0.0001f)
+        assertEquals(0.25f, mapped.top, 0.0001f)
+        assertEquals((96f + 432f) / 768f, mapped.right, 0.0001f)
+        assertEquals(0.75f, mapped.bottom, 0.0001f)
+    }
+
+    @Test
+    fun squareFrameKeepsWholeSourceCoordinates() {
+        val transform =
+            SquareCropTransform.from(
+                sourceWidth = 512,
+                sourceHeight = 512,
+                inputWidth = 512,
+                inputHeight = 512
+            )
+
+        assertEquals(0, transform.cropLeft)
+        assertEquals(0, transform.cropTop)
+        assertEquals(512, transform.cropSize)
+
+        val mapped =
+            transform.inputBoundsToSourceNormalized(
+                left = 0.1f,
+                top = 0.2f,
+                right = 0.8f,
+                bottom = 0.9f
+            )
+
+        requireNotNull(mapped)
+        assertEquals(0.1f, mapped.left, 0.0001f)
+        assertEquals(0.2f, mapped.top, 0.0001f)
+        assertEquals(0.8f, mapped.right, 0.0001f)
+        assertEquals(0.9f, mapped.bottom, 0.0001f)
+    }
+}


### PR DESCRIPTION
## 요약
- YOLO 입력 전처리를 stretch/letterbox 대신 centered square crop으로 변경
- 세로 프레임은 상/하단을, 가로 프레임은 좌/우를 중앙 기준으로 crop해 모델 입력 정사각형에 맞춤
- 모델 출력 박스는 crop offset을 반영해 원본 bitmap normalized 좌표로 inverse mapping
- overlay, SignalAnalyzer, PostProcessor는 계속 원본 프레임 좌표를 받음

## 왜 letterbox가 아닌 crop인가
- 실기기 테스트에서 letterbox는 768x576 프레임 내용을 512x384로 줄여 작은 신호등 픽셀 수가 감소했고 인식률이 떨어졌음
- 데모/횡단보도 신호등은 대체로 중앙부를 겨냥하므로, 상/하단 일부를 버리더라도 중앙 객체 scale을 유지하는 crop이 더 유리함
- 배터리 최적화는 카메라 FPS/분석 해상도/processed FPS 제한으로 유지하고, 모델 입력 단계에서는 추가 루프 없이 기존 resize 경로를 대체함

## 검증
- `./gradlew testDebugUnitTest --tests 'kr.co.gachon.pproject6.via.ml.SquareCropTransformTest'`
- `./gradlew testDebugUnitTest lintDebug assembleDebug`
- `adb install -r app/build/outputs/apk/debug/app-debug.apk`

Closes #69
