### PR TITLE
feat: 도움말에 소리·진동 연습 모드 추가

### DIFF
--- a/app/src/main/java/kr/co/gachon/pproject6/via/feedback/SignalFeedbackManager.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/feedback/SignalFeedbackManager.kt
@@ -64,28 +64,8 @@ class SignalFeedbackManager(context: Context) : TextToSpeech.OnInitListener {
             return
         }
 
-        when (assessment.state) {
-            AdvisoryState.RED_CONFIRMED -> {
-                speak(assessment.speechText)
-                vibrate(longArrayOf(0, 400, 200, 400))
-            }
-
-            AdvisoryState.GREEN_CONFIRMED -> {
-                speak(assessment.speechText)
-                vibrate(longArrayOf(0, 180, 120, 180, 120, 180))
-            }
-
-            AdvisoryState.GREEN_WITH_CAUTION -> {
-                speak(assessment.speechText)
-                vibrate(longArrayOf(0, 150, 100, 150, 250, 150))
-            }
-
-            AdvisoryState.TRANSITION_WAIT,
-            AdvisoryState.UNCERTAIN_VIEW -> {
-                speak(assessment.speechText)
-                vibrate(longArrayOf(0, 140))
-            }
-        }
+        speak(assessment.speechText)
+        vibrate(SignalFeedbackPatterns.forAdvisoryState(assessment.state))
     }
 
     fun clearState() {

--- a/app/src/main/java/kr/co/gachon/pproject6/via/feedback/SignalFeedbackPatterns.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/feedback/SignalFeedbackPatterns.kt
@@ -1,0 +1,29 @@
+package kr.co.gachon.pproject6.via.feedback
+
+import kr.co.gachon.pproject6.via.ml.AdvisoryState
+
+enum class SignalFeedbackPattern {
+    RED_CONFIRMED,
+    GREEN_CONFIRMED,
+    GREEN_WITH_CAUTION,
+    WAIT_OR_UNCERTAIN
+}
+
+object SignalFeedbackPatterns {
+    fun forAdvisoryState(state: AdvisoryState): LongArray =
+        when (state) {
+            AdvisoryState.RED_CONFIRMED -> copyOf(SignalFeedbackPattern.RED_CONFIRMED)
+            AdvisoryState.GREEN_CONFIRMED -> copyOf(SignalFeedbackPattern.GREEN_CONFIRMED)
+            AdvisoryState.GREEN_WITH_CAUTION -> copyOf(SignalFeedbackPattern.GREEN_WITH_CAUTION)
+            AdvisoryState.TRANSITION_WAIT,
+            AdvisoryState.UNCERTAIN_VIEW -> copyOf(SignalFeedbackPattern.WAIT_OR_UNCERTAIN)
+        }
+
+    fun copyOf(pattern: SignalFeedbackPattern): LongArray =
+        when (pattern) {
+            SignalFeedbackPattern.RED_CONFIRMED -> longArrayOf(0, 400, 200, 400)
+            SignalFeedbackPattern.GREEN_CONFIRMED -> longArrayOf(0, 180, 120, 180, 120, 180)
+            SignalFeedbackPattern.GREEN_WITH_CAUTION -> longArrayOf(0, 150, 100, 150, 250, 150)
+            SignalFeedbackPattern.WAIT_OR_UNCERTAIN -> longArrayOf(0, 140)
+        }
+}

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/PracticeFeedbackPlayer.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/PracticeFeedbackPlayer.kt
@@ -1,0 +1,85 @@
+package kr.co.gachon.pproject6.via.guide
+
+import android.content.Context
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import android.speech.tts.TextToSpeech
+import java.util.Locale
+import kr.co.gachon.pproject6.via.feedback.SignalFeedbackPatterns
+
+class PracticeFeedbackPlayer(context: Context) : TextToSpeech.OnInitListener {
+    private val appContext = context.applicationContext
+    private val tts = TextToSpeech(appContext, this)
+    private val vibrator: Vibrator? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            appContext.getSystemService(VibratorManager::class.java)?.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            appContext.getSystemService(Context.VIBRATOR_SERVICE) as? Vibrator
+        }
+
+    private var ttsReady = false
+
+    override fun onInit(status: Int) {
+        if (status != TextToSpeech.SUCCESS) {
+            return
+        }
+
+        val preferred = tts.setLanguage(Locale.KOREAN)
+        if (preferred == TextToSpeech.LANG_MISSING_DATA || preferred == TextToSpeech.LANG_NOT_SUPPORTED) {
+            tts.setLanguage(Locale.getDefault())
+        }
+        ttsReady = true
+    }
+
+    fun play(example: PracticeFeedbackExample): Boolean {
+        if (!example.simulationOnly || !ttsReady) {
+            return false
+        }
+
+        stop()
+        speak(example.speechText, "practice_${example.id}")
+        example.hapticPattern?.let { vibrate(SignalFeedbackPatterns.copyOf(it)) }
+        return true
+    }
+
+    fun stop() {
+        tts.stop()
+        cancelVibration()
+    }
+
+    fun release() {
+        stop()
+        tts.shutdown()
+    }
+
+    private fun speak(message: String, utteranceId: String) {
+        tts.speak(message, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
+    }
+
+    private fun vibrate(pattern: LongArray) {
+        val targetVibrator = vibrator
+        if (targetVibrator == null || !targetVibrator.hasVibrator()) {
+            return
+        }
+
+        cancelVibration()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            targetVibrator.vibrate(VibrationEffect.createWaveform(pattern, -1))
+        } else {
+            @Suppress("DEPRECATION")
+            targetVibrator.vibrate(pattern, -1)
+        }
+    }
+
+    private fun cancelVibration() {
+        val targetVibrator = vibrator
+        if (targetVibrator == null || !targetVibrator.hasVibrator()) {
+            return
+        }
+
+        targetVibrator.cancel()
+    }
+}

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.google.android.material.button.MaterialButton
@@ -13,9 +14,22 @@ import com.google.android.material.card.MaterialCardView
 import kr.co.gachon.pproject6.via.R
 
 class UsageGuideActivity : AppCompatActivity() {
+    private lateinit var practiceFeedbackPlayer: PracticeFeedbackPlayer
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        practiceFeedbackPlayer = PracticeFeedbackPlayer(this)
         setContentView(createContentView())
+    }
+
+    override fun onPause() {
+        super.onPause()
+        practiceFeedbackPlayer.stop()
+    }
+
+    override fun onDestroy() {
+        practiceFeedbackPlayer.release()
+        super.onDestroy()
     }
 
     private fun createContentView(): ScrollView {
@@ -45,8 +59,40 @@ class UsageGuideActivity : AppCompatActivity() {
                 matchWrap(topMargin = 16)
             )
         }
+        content.addView(practiceCard(), matchWrap(topMargin = 16))
         return root
     }
+
+    private fun practiceCard(): MaterialCardView =
+        card {
+            addView(sectionTitleText("연습 모드"), matchWrap())
+            addView(
+                bodyText("아래 버튼은 사용법을 익히기 위한 예시입니다. 실제 카메라 분석, 위치 조회, 비상 문자, 실시간 안내를 실행하지 않습니다."),
+                matchWrap(topMargin = 8)
+            )
+            addView(sectionSubtitleText("소리와 진동 연습"), matchWrap(topMargin = 16))
+            UsageGuidePracticeContent.signalExamples.forEach { example ->
+                addView(practiceButton(example), matchWrap(topMargin = 8))
+            }
+            addView(sectionSubtitleText("버튼 조작 연습"), matchWrap(topMargin = 18))
+            UsageGuidePracticeContent.controlExamples.forEach { example ->
+                addView(practiceButton(example), matchWrap(topMargin = 8))
+                addView(bodyText(example.description), matchWrap(topMargin = 4))
+            }
+        }
+
+    private fun practiceButton(example: PracticeFeedbackExample): MaterialButton =
+        MaterialButton(this).apply {
+            text = example.title
+            isAllCaps = false
+            minHeight = dp(48)
+            setOnClickListener {
+                val played = practiceFeedbackPlayer.play(example)
+                if (!played) {
+                    Toast.makeText(this@UsageGuideActivity, "음성 엔진을 준비 중입니다. 잠시 후 다시 눌러 주세요.", Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
 
     private fun card(contentBuilder: LinearLayout.() -> Unit): MaterialCardView {
         val cardContent = LinearLayout(this).apply {
@@ -77,6 +123,14 @@ class UsageGuideActivity : AppCompatActivity() {
             this.text = text
             setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))
             textSize = 22f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+        }
+
+    private fun sectionSubtitleText(text: String): TextView =
+        TextView(this).apply {
+            this.text = text
+            setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))
+            textSize = 18f
             setTypeface(typeface, android.graphics.Typeface.BOLD)
         }
 

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
@@ -99,7 +99,7 @@ class UsageGuideActivity : AppCompatActivity() {
             isClickable = true
             isFocusable = true
             minimumHeight = dp(156)
-            contentDescription = "${example.title}. 두 번 탭하면 예시를 재생합니다."
+            contentDescription = "${example.title}. 누르면 안내 예시를 재생합니다."
             setOnClickListener { playPractice(example) }
             addView(
                 signalCircle(example),
@@ -163,7 +163,7 @@ class UsageGuideActivity : AppCompatActivity() {
                 )
                 addView(bodyText(example.description), matchWrap(topMargin = 6))
                 addView(
-                    accentText("두 번 탭하면 실제 동작 안내 예시를 재생합니다."),
+                    bodyText("누르면 실제 사용 때 나오는 안내 예시를 들려줍니다."),
                     matchWrap(topMargin = 8)
                 )
             }
@@ -177,7 +177,7 @@ class UsageGuideActivity : AppCompatActivity() {
             isClickable = true
             isFocusable = true
             minimumHeight = dp(116)
-            contentDescription = "${example.title}. ${example.description}. 두 번 탭하면 실제 동작 안내 예시를 재생합니다."
+            contentDescription = "${example.title}. ${example.description}. 누르면 실제 사용 때 나오는 안내 예시를 재생합니다."
             setOnClickListener { playPractice(example) }
             addView(itemContent, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         }
@@ -193,7 +193,10 @@ class UsageGuideActivity : AppCompatActivity() {
         val played = practiceFeedbackPlayer.play(example)
         if (!played) {
             Toast.makeText(this, "음성 엔진을 준비 중입니다. 잠시 후 다시 눌러 주세요.", Toast.LENGTH_SHORT).show()
+            return
         }
+
+        Toast.makeText(this, example.speechText.removePrefix("연습 예시입니다.").trim(), Toast.LENGTH_LONG).show()
     }
 
     private fun signalSymbol(exampleId: String): String =

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
@@ -96,6 +96,11 @@ class UsageGuideActivity : AppCompatActivity() {
         LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
             gravity = Gravity.CENTER_HORIZONTAL
+            isClickable = true
+            isFocusable = true
+            minimumHeight = dp(156)
+            contentDescription = "${example.title}. 두 번 탭하면 예시를 재생합니다."
+            setOnClickListener { playPractice(example) }
             addView(
                 signalCircle(example),
                 LinearLayout.LayoutParams(dp(72), dp(72)).apply { gravity = Gravity.CENTER_HORIZONTAL }
@@ -138,10 +143,45 @@ class UsageGuideActivity : AppCompatActivity() {
             addView(sectionTitleText(UsageGuideContent.quickActions.title), matchWrap())
             addView(bodyText(UsageGuideContent.quickActions.body), matchWrap(topMargin = 8))
             UsageGuidePracticeContent.controlExamples.forEach { example ->
-                addView(playButton(example).apply { text = "▶ ${example.title} 예시" }, matchWrap(topMargin = 10))
-                addView(bodyText(example.description), matchWrap(topMargin = 4))
+                addView(quickActionItem(example), matchWrap(topMargin = 12))
             }
         }
+
+    private fun quickActionItem(example: PracticeFeedbackExample): MaterialCardView {
+        val itemContent =
+            LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                setPadding(dp(18), dp(16), dp(18), dp(16))
+                addView(
+                    TextView(this@UsageGuideActivity).apply {
+                        text = "▶ ${example.title}"
+                        setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))
+                        textSize = 20f
+                        setTypeface(typeface, Typeface.BOLD)
+                    },
+                    matchWrap()
+                )
+                addView(bodyText(example.description), matchWrap(topMargin = 6))
+                addView(
+                    accentText("두 번 탭하면 실제 동작 안내 예시를 재생합니다."),
+                    matchWrap(topMargin = 8)
+                )
+            }
+
+        return MaterialCardView(this).apply {
+            radius = dp(18).toFloat()
+            cardElevation = 0f
+            setCardBackgroundColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_accent_container))
+            strokeColor = ContextCompat.getColor(this@UsageGuideActivity, R.color.via_surface_outline)
+            strokeWidth = dp(1)
+            isClickable = true
+            isFocusable = true
+            minimumHeight = dp(116)
+            contentDescription = "${example.title}. ${example.description}. 두 번 탭하면 실제 동작 안내 예시를 재생합니다."
+            setOnClickListener { playPractice(example) }
+            addView(itemContent, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+        }
+    }
 
     private fun infoCard(section: UsageGuideSection): MaterialCardView =
         card {

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideActivity.kt
@@ -1,7 +1,11 @@
 package kr.co.gachon.pproject6.via.guide
 
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.ScrollView
@@ -44,55 +48,132 @@ class UsageGuideActivity : AppCompatActivity() {
         root.addView(content, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
 
         content.addView(backButton().apply { setOnClickListener { finish() } })
-        content.addView(titleText("앱 사용 안내"), matchWrap(topMargin = 8))
-        content.addView(
-            bodyText("VIA는 보행 판단을 대신하지 않고, 신호·횡단보도·비상 연락을 보조적으로 안내합니다."),
-            matchWrap(topMargin = 8)
-        )
+        content.addView(titleText(UsageGuideContent.screenTitle), matchWrap(topMargin = 8))
+        content.addView(bodyText(UsageGuideContent.intro), matchWrap(topMargin = 8))
+        content.addView(feedbackPracticeCard(), matchWrap(topMargin = 20))
 
-        UsageGuideContent.sections.forEach { section ->
-            content.addView(
-                card {
-                    addView(sectionTitleText(section.title), matchWrap())
-                    addView(bodyText(section.body), matchWrap(topMargin = 8))
-                },
-                matchWrap(topMargin = 16)
-            )
+        UsageGuideContent.compactSections.forEach { section ->
+            content.addView(infoCard(section), matchWrap(topMargin = 18))
         }
-        content.addView(practiceCard(), matchWrap(topMargin = 16))
+        content.addView(quickActionsCard(), matchWrap(topMargin = 18))
+        content.addView(infoCard(UsageGuideContent.safetyNote), matchWrap(topMargin = 18))
         return root
     }
 
-    private fun practiceCard(): MaterialCardView =
+    private fun feedbackPracticeCard(): MaterialCardView =
         card {
-            addView(sectionTitleText("연습 모드"), matchWrap())
+            addView(sectionTitleText(UsageGuideContent.feedbackOverview.title), matchWrap())
+            addView(bodyText(UsageGuideContent.feedbackOverview.body), matchWrap(topMargin = 8))
+            addView(signalPracticeGrid(), matchWrap(topMargin = 20))
             addView(
-                bodyText("아래 버튼은 사용법을 익히기 위한 예시입니다. 실제 카메라 분석, 위치 조회, 비상 문자, 실시간 안내를 실행하지 않습니다."),
+                accentText("소리와 진동은 설정에 따라 다르게 느껴질 수 있습니다."),
+                matchWrap(topMargin = 18)
+            )
+        }
+
+    private fun signalPracticeGrid(): LinearLayout =
+        LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            UsageGuidePracticeContent.signalExamples.chunked(2).forEachIndexed { rowIndex, rowExamples ->
+                addView(
+                    LinearLayout(this@UsageGuideActivity).apply {
+                        orientation = LinearLayout.HORIZONTAL
+                        rowExamples.forEachIndexed { index, example ->
+                            addView(
+                                signalPracticeItem(example),
+                                LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f).apply {
+                                    if (index > 0) setMargins(dp(10), 0, 0, 0)
+                                }
+                            )
+                        }
+                    },
+                    matchWrap(topMargin = if (rowIndex == 0) 0 else 16)
+                )
+            }
+        }
+
+    private fun signalPracticeItem(example: PracticeFeedbackExample): LinearLayout =
+        LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+            addView(
+                signalCircle(example),
+                LinearLayout.LayoutParams(dp(72), dp(72)).apply { gravity = Gravity.CENTER_HORIZONTAL }
+            )
+            addView(
+                bodyText(example.title).apply {
+                    gravity = Gravity.CENTER
+                    textAlignment = View.TEXT_ALIGNMENT_CENTER
+                    setTypeface(typeface, Typeface.BOLD)
+                },
                 matchWrap(topMargin = 8)
             )
-            addView(sectionSubtitleText("소리와 진동 연습"), matchWrap(topMargin = 16))
-            UsageGuidePracticeContent.signalExamples.forEach { example ->
-                addView(practiceButton(example), matchWrap(topMargin = 8))
+            addView(playButton(example), matchWrap(topMargin = 8))
+        }
+
+    private fun signalCircle(example: PracticeFeedbackExample): TextView =
+        TextView(this).apply {
+            text = signalSymbol(example.id)
+            gravity = Gravity.CENTER
+            textSize = 30f
+            setTextColor(Color.WHITE)
+            background = GradientDrawable().apply {
+                shape = GradientDrawable.OVAL
+                setColor(signalColor(example.id))
             }
-            addView(sectionSubtitleText("버튼 조작 연습"), matchWrap(topMargin = 18))
+            contentDescription = example.title
+        }
+
+    private fun playButton(example: PracticeFeedbackExample): MaterialButton =
+        MaterialButton(this, null, com.google.android.material.R.attr.borderlessButtonStyle).apply {
+            text = "▶ 재생"
+            isAllCaps = false
+            minHeight = dp(44)
+            setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_status_caution))
+            setOnClickListener { playPractice(example) }
+        }
+
+    private fun quickActionsCard(): MaterialCardView =
+        card {
+            addView(sectionTitleText(UsageGuideContent.quickActions.title), matchWrap())
+            addView(bodyText(UsageGuideContent.quickActions.body), matchWrap(topMargin = 8))
             UsageGuidePracticeContent.controlExamples.forEach { example ->
-                addView(practiceButton(example), matchWrap(topMargin = 8))
+                addView(playButton(example).apply { text = "▶ ${example.title} 예시" }, matchWrap(topMargin = 10))
                 addView(bodyText(example.description), matchWrap(topMargin = 4))
             }
         }
 
-    private fun practiceButton(example: PracticeFeedbackExample): MaterialButton =
-        MaterialButton(this).apply {
-            text = example.title
-            isAllCaps = false
-            minHeight = dp(48)
-            setOnClickListener {
-                val played = practiceFeedbackPlayer.play(example)
-                if (!played) {
-                    Toast.makeText(this@UsageGuideActivity, "음성 엔진을 준비 중입니다. 잠시 후 다시 눌러 주세요.", Toast.LENGTH_SHORT).show()
-                }
-            }
+    private fun infoCard(section: UsageGuideSection): MaterialCardView =
+        card {
+            addView(sectionTitleText(section.title), matchWrap())
+            addView(bodyText(section.body), matchWrap(topMargin = 8))
         }
+
+    private fun playPractice(example: PracticeFeedbackExample) {
+        val played = practiceFeedbackPlayer.play(example)
+        if (!played) {
+            Toast.makeText(this, "음성 엔진을 준비 중입니다. 잠시 후 다시 눌러 주세요.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun signalSymbol(exampleId: String): String =
+        when (exampleId) {
+            "practice_signal_red" -> "✋"
+            "practice_signal_green" -> "🚶"
+            "practice_signal_green_caution" -> "!"
+            else -> "?"
+        }
+
+    private fun signalColor(exampleId: String): Int =
+        ContextCompat.getColor(
+            this,
+            when (exampleId) {
+                "practice_signal_red" -> R.color.via_status_stop
+                "practice_signal_green" -> R.color.via_status_go
+                "practice_signal_green_caution" -> R.color.via_status_caution
+                else -> R.color.via_status_wait
+            }
+        )
 
     private fun card(contentBuilder: LinearLayout.() -> Unit): MaterialCardView {
         val cardContent = LinearLayout(this).apply {
@@ -115,23 +196,15 @@ class UsageGuideActivity : AppCompatActivity() {
             this.text = text
             setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))
             textSize = 34f
-            setTypeface(typeface, android.graphics.Typeface.BOLD)
+            setTypeface(typeface, Typeface.BOLD)
         }
 
     private fun sectionTitleText(text: String): TextView =
         TextView(this).apply {
             this.text = text
             setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))
-            textSize = 22f
-            setTypeface(typeface, android.graphics.Typeface.BOLD)
-        }
-
-    private fun sectionSubtitleText(text: String): TextView =
-        TextView(this).apply {
-            this.text = text
-            setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))
-            textSize = 18f
-            setTypeface(typeface, android.graphics.Typeface.BOLD)
+            textSize = 24f
+            setTypeface(typeface, Typeface.BOLD)
         }
 
     private fun bodyText(text: String): TextView =
@@ -139,6 +212,14 @@ class UsageGuideActivity : AppCompatActivity() {
             this.text = text
             setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface_variant))
             textSize = 16f
+            setLineSpacing(dp(4).toFloat(), 1f)
+        }
+
+    private fun accentText(text: String): TextView =
+        TextView(this).apply {
+            this.text = text
+            setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_status_caution))
+            textSize = 15f
             setLineSpacing(dp(4).toFloat(), 1f)
         }
 
@@ -155,7 +236,7 @@ class UsageGuideActivity : AppCompatActivity() {
             gravity = Gravity.CENTER_VERTICAL or Gravity.START
             minWidth = 0
             setPadding(0, paddingTop, dp(12), paddingBottom)
-            textAlignment = android.view.View.TEXT_ALIGNMENT_TEXT_START
+            textAlignment = View.TEXT_ALIGNMENT_TEXT_START
             textSize = 16f
             minHeight = dp(48)
             setTextColor(ContextCompat.getColor(this@UsageGuideActivity, R.color.via_on_surface))

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideContent.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideContent.kt
@@ -36,7 +36,7 @@ object UsageGuideContent {
     val quickActions: UsageGuideSection =
         UsageGuideSection(
             title = "빠른 조작",
-            body = "주변 횡단보도 안내와 블루투스 버튼 동작을 예시로 들어볼 수 있습니다. 예시는 실제 위치 조회나 비상 연락을 실행하지 않습니다."
+            body = "주변 횡단보도 안내와 블루투스 버튼 동작을 예시로 들어볼 수 있습니다. 짧게 누르면 주변 횡단보도 안내, 길게 누르면 비상 문자 5초 유예 화면을 엽니다."
         )
 
     val safetyNote: UsageGuideSection =

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideContent.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuideContent.kt
@@ -6,35 +6,48 @@ data class UsageGuideSection(
 )
 
 object UsageGuideContent {
-    val sections: List<UsageGuideSection> =
-        listOf(
-            UsageGuideSection(
-                title = "VIA가 하는 일",
-                body = "VIA는 보행자 신호와 주변 횡단보도 정보를 보조적으로 안내합니다. 실제 이동 전에는 반드시 차량, 자전거, 주변 사람, 노면 상태를 직접 확인해야 합니다."
-            ),
-            UsageGuideSection(
-                title = "중요 안전 안내",
-                body = "VIA는 보행 판단을 보조하는 앱이며 최종 판단을 대신하지 않습니다. 안내가 불확실하거나 주변 상황과 다르면 멈추고 주변 도움을 요청해 주세요."
-            ),
-            UsageGuideSection(
-                title = "권한을 쓰는 이유",
-                body = "카메라는 보행자 신호를 확인하는 데 사용합니다. 위치는 가까운 횡단보도 거리와 방향을 안내하는 데 사용합니다. SMS 권한은 사용자가 등록한 보호자나 기관에 비상 문자를 자동 발송할 때만 사용합니다."
-            ),
-            UsageGuideSection(
-                title = "주요 기능",
-                body = "신호 상태 안내는 카메라로 보이는 보행자 신호를 음성과 화면으로 알려줍니다. 주변 횡단보도 안내는 현재 위치 기준 가까운 횡단보도의 거리와 방향만 알려줍니다. 비상 문자는 5초 유예 후 등록된 연락처로 발송되며 취소할 수 있습니다. 사용법은 메인 화면 상단 ? 버튼에서 다시 열 수 있습니다."
-            ),
-            UsageGuideSection(
-                title = "블루투스 버튼",
-                body = "Space 키로 동작하는 블루투스 버튼을 사용할 수 있습니다. 짧게 누르면 주변 횡단보도 안내를 실행하고, 길게 누르면 비상 문자 5초 유예 화면을 엽니다. 화면 버튼으로도 같은 기능을 사용할 수 있습니다."
-            ),
-            UsageGuideSection(
-                title = "상태 문구의 의미",
-                body = "보행자 신호 초록으로 보임은 카메라에서 보행자 초록 신호가 확인되고 보수적 확인 조건을 통과한 상태입니다. 보행자 신호 빨간색으로 보임은 보행자 빨간 신호가 확인된 상태입니다. 초록으로 보이나 주의 필요는 초록 신호가 보이지만 차량 점유 등 주변 주의가 필요한 상태입니다. 신호 확인 불확실은 카메라 시야나 인식 신뢰도가 부족한 상태입니다. 다음 신호 대기 권장은 새로운 신호 주기를 기다리는 것이 더 안전하다는 뜻입니다."
-            ),
-            UsageGuideSection(
-                title = "초기 최적화",
-                body = "첫 실행 시 앱은 기기에서 사용할 AI 모델과 실행 방식을 짧게 측정합니다. 측정 중에는 휴대폰을 안정적으로 들고 카메라 권한을 유지해 주세요. 설정의 디버그 패널에서 모델과 FPS를 다시 확인할 수 있습니다."
-            )
+    const val screenTitle: String = "사용 안내"
+    const val intro: String = "VIA는 보행 판단을 보조합니다. 실제 이동 전 주변을 직접 확인하세요."
+
+    val feedbackOverview: UsageGuideSection =
+        UsageGuideSection(
+            title = "어떤 피드백을 받나요?",
+            body = "VIA는 보행자 신호를 음성, 진동, 화면으로 알려줍니다. 아래 예시를 눌러 소리와 진동을 먼저 확인해 보세요."
         )
+
+    val howItWorks: UsageGuideSection =
+        UsageGuideSection(
+            title = "어떻게 작동하나요?",
+            body = "카메라로 보이는 보행자 신호를 확인하고, 현재 상태를 보조 안내로 전달합니다. 안내가 실제 상황과 다르면 주변 상황을 우선하세요."
+        )
+
+    val phoneHold: UsageGuideSection =
+        UsageGuideSection(
+            title = "휴대폰은 어떻게 들까요?",
+            body = "휴대폰을 가슴 앞에 두고 카메라가 건너려는 방향을 보게 합니다. 신호가 보이지 않으면 몸을 천천히 돌려 방향을 다시 맞추세요."
+        )
+
+    val noFeedback: UsageGuideSection =
+        UsageGuideSection(
+            title = "피드백이 없으면?",
+            body = "신호가 화면 밖에 있거나 사람·차량에 가려졌을 수 있습니다. 멈춘 뒤 휴대폰 방향을 다시 맞추고, 필요하면 주변 도움을 요청하세요."
+        )
+
+    val quickActions: UsageGuideSection =
+        UsageGuideSection(
+            title = "빠른 조작",
+            body = "주변 횡단보도 안내와 블루투스 버튼 동작을 예시로 들어볼 수 있습니다. 예시는 실제 위치 조회나 비상 연락을 실행하지 않습니다."
+        )
+
+    val safetyNote: UsageGuideSection =
+        UsageGuideSection(
+            title = "안전 안내",
+            body = "VIA는 보조 도구이며 보행 판단을 대신하지 않습니다. 건너기 전에는 항상 차량, 자전거, 주변 사람, 노면 상태를 직접 확인하세요."
+        )
+
+    val compactSections: List<UsageGuideSection> =
+        listOf(howItWorks, phoneHold, noFeedback)
+
+    val sections: List<UsageGuideSection> =
+        compactSections + quickActions + safetyNote
 }

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuidePracticeContent.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuidePracticeContent.kt
@@ -1,0 +1,87 @@
+package kr.co.gachon.pproject6.via.guide
+
+import kr.co.gachon.pproject6.via.feedback.SignalFeedbackPattern
+
+enum class PracticeFeedbackCategory {
+    SIGNAL,
+    CONTROL
+}
+
+data class PracticeFeedbackExample(
+    val id: String,
+    val category: PracticeFeedbackCategory,
+    val title: String,
+    val description: String,
+    val speechText: String,
+    val hapticPattern: SignalFeedbackPattern?,
+    val simulationOnly: Boolean = true
+)
+
+object UsageGuidePracticeContent {
+    val signalExamples: List<PracticeFeedbackExample> =
+        listOf(
+            PracticeFeedbackExample(
+                id = "practice_signal_red",
+                category = PracticeFeedbackCategory.SIGNAL,
+                title = "빨간불 예시 듣기",
+                description = "빨간 보행자 신호가 보일 때의 안내 예시입니다.",
+                speechText = "연습 예시입니다. 빨간불로 보입니다. 실제 이동 전 주변을 확인하세요.",
+                hapticPattern = SignalFeedbackPattern.RED_CONFIRMED
+            ),
+            PracticeFeedbackExample(
+                id = "practice_signal_green",
+                category = PracticeFeedbackCategory.SIGNAL,
+                title = "초록불 예시 듣기",
+                description = "초록 보행자 신호가 확인됐을 때의 안내 예시입니다.",
+                speechText = "연습 예시입니다. 초록불로 보입니다. 실제 이동 전 주변을 확인하세요.",
+                hapticPattern = SignalFeedbackPattern.GREEN_CONFIRMED
+            ),
+            PracticeFeedbackExample(
+                id = "practice_signal_green_caution",
+                category = PracticeFeedbackCategory.SIGNAL,
+                title = "초록불 주의 예시 듣기",
+                description = "초록 신호처럼 보여도 차량이나 주변 상황을 더 조심해야 할 때의 예시입니다.",
+                speechText = "연습 예시입니다. 초록불로 보여도 차량을 주의하세요.",
+                hapticPattern = SignalFeedbackPattern.GREEN_WITH_CAUTION
+            ),
+            PracticeFeedbackExample(
+                id = "practice_signal_uncertain",
+                category = PracticeFeedbackCategory.SIGNAL,
+                title = "확인 필요 예시 듣기",
+                description = "신호가 불확실하거나 카메라 시야가 부족할 때의 안내 예시입니다.",
+                speechText = "연습 예시입니다. 확인이 필요합니다. 멈추고 주변을 확인하세요.",
+                hapticPattern = SignalFeedbackPattern.WAIT_OR_UNCERTAIN
+            )
+        )
+
+    val controlExamples: List<PracticeFeedbackExample> =
+        listOf(
+            PracticeFeedbackExample(
+                id = "practice_control_nearby_crosswalk",
+                category = PracticeFeedbackCategory.CONTROL,
+                title = "주변 횡단보도 안내",
+                description = "메인 화면 버튼이나 블루투스 짧은 누름으로 실행하는 기능의 설명 예시입니다.",
+                speechText = "연습 예시입니다. 주변 횡단보도 안내는 현재 위치 기준 가까운 횡단보도의 거리와 방향을 알려줍니다. 지금은 실제 위치를 조회하지 않습니다.",
+                hapticPattern = null
+            ),
+            PracticeFeedbackExample(
+                id = "practice_control_short_press",
+                category = PracticeFeedbackCategory.CONTROL,
+                title = "블루투스 짧게 누르기",
+                description = "Space 키 방식 리모컨을 짧게 눌렀을 때의 설명 예시입니다.",
+                speechText = "연습 예시입니다. 블루투스 버튼을 짧게 누르면 주변 횡단보도 안내를 요청합니다. 지금은 실제 안내를 실행하지 않습니다.",
+                hapticPattern = null
+            ),
+            PracticeFeedbackExample(
+                id = "practice_control_long_press",
+                category = PracticeFeedbackCategory.CONTROL,
+                title = "블루투스 길게 누르기",
+                description = "Space 키 방식 리모컨을 길게 눌렀을 때의 설명 예시입니다.",
+                speechText = "연습 예시입니다. 블루투스 버튼을 길게 누르면 비상 문자 5초 유예 화면을 엽니다. 지금은 비상 연락을 실행하지 않습니다.",
+                hapticPattern = null
+            )
+        )
+
+    val allExamples: List<PracticeFeedbackExample> =
+        signalExamples + controlExamples
+}

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuidePracticeContent.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuidePracticeContent.kt
@@ -60,24 +60,24 @@ object UsageGuidePracticeContent {
                 id = "practice_control_nearby_crosswalk",
                 category = PracticeFeedbackCategory.CONTROL,
                 title = "주변 횡단보도 안내",
-                description = "메인 화면 버튼이나 블루투스 짧은 누름으로 실행하는 기능의 설명 예시입니다.",
-                speechText = "연습 예시입니다. 주변 횡단보도 안내는 현재 위치 기준 가까운 횡단보도의 거리와 방향을 알려줍니다. 지금은 실제 위치를 조회하지 않습니다.",
+                description = "메인 화면 버튼이나 블루투스 버튼을 짧게 눌렀을 때 실행되는 기능입니다.",
+                speechText = "연습 예시입니다. 주변 횡단보도 안내는 현재 위치 기준 가까운 횡단보도의 거리와 방향을 알려줍니다.",
                 hapticPattern = null
             ),
             PracticeFeedbackExample(
                 id = "practice_control_short_press",
                 category = PracticeFeedbackCategory.CONTROL,
                 title = "블루투스 짧게 누르기",
-                description = "Space 키 방식 리모컨을 짧게 눌렀을 때의 설명 예시입니다.",
-                speechText = "연습 예시입니다. 블루투스 버튼을 짧게 누르면 주변 횡단보도 안내를 요청합니다. 지금은 실제 안내를 실행하지 않습니다.",
+                description = "블루투스 버튼을 짧게 눌렀을 때의 동작입니다.",
+                speechText = "연습 예시입니다. 블루투스 버튼을 짧게 누르면 주변 횡단보도 안내를 실행합니다.",
                 hapticPattern = null
             ),
             PracticeFeedbackExample(
                 id = "practice_control_long_press",
                 category = PracticeFeedbackCategory.CONTROL,
                 title = "블루투스 길게 누르기",
-                description = "Space 키 방식 리모컨을 길게 눌렀을 때의 설명 예시입니다.",
-                speechText = "연습 예시입니다. 블루투스 버튼을 길게 누르면 비상 문자 5초 유예 화면을 엽니다. 지금은 비상 연락을 실행하지 않습니다.",
+                description = "블루투스 버튼을 길게 눌렀을 때의 동작입니다.",
+                speechText = "연습 예시입니다. 블루투스 버튼을 길게 누르면 비상 문자 5초 유예 화면을 엽니다. 유예 시간 안에 취소할 수 있습니다.",
                 hapticPattern = null
             )
         )

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuidePracticeContent.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuidePracticeContent.kt
@@ -61,7 +61,7 @@ object UsageGuidePracticeContent {
                 category = PracticeFeedbackCategory.CONTROL,
                 title = "주변 횡단보도 안내",
                 description = "메인 화면 버튼이나 블루투스 버튼을 짧게 눌렀을 때 실행되는 기능입니다.",
-                speechText = "연습 예시입니다. 주변 횡단보도 안내는 현재 위치 기준 가까운 횡단보도의 거리와 방향을 알려줍니다.",
+                speechText = "연습 예시입니다. 가장 가까운 횡단보도는 전방 약 18미터에 있습니다.",
                 hapticPattern = null
             ),
             PracticeFeedbackExample(
@@ -69,7 +69,7 @@ object UsageGuidePracticeContent {
                 category = PracticeFeedbackCategory.CONTROL,
                 title = "블루투스 짧게 누르기",
                 description = "블루투스 버튼을 짧게 눌렀을 때의 동작입니다.",
-                speechText = "연습 예시입니다. 블루투스 버튼을 짧게 누르면 주변 횡단보도 안내를 실행합니다.",
+                speechText = "연습 예시입니다. 주변 횡단보도 안내를 실행합니다. 가장 가까운 횡단보도는 전방 약 18미터에 있습니다.",
                 hapticPattern = null
             ),
             PracticeFeedbackExample(
@@ -77,7 +77,7 @@ object UsageGuidePracticeContent {
                 category = PracticeFeedbackCategory.CONTROL,
                 title = "블루투스 길게 누르기",
                 description = "블루투스 버튼을 길게 눌렀을 때의 동작입니다.",
-                speechText = "연습 예시입니다. 블루투스 버튼을 길게 누르면 비상 문자 5초 유예 화면을 엽니다. 유예 시간 안에 취소할 수 있습니다.",
+                speechText = "연습 예시입니다. 비상 문자 화면을 엽니다. 5초 안에 취소하지 않으면 등록된 비상 연락처로 문자를 보냅니다.",
                 hapticPattern = null
             )
         )

--- a/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuidePracticeContent.kt
+++ b/app/src/main/java/kr/co/gachon/pproject6/via/guide/UsageGuidePracticeContent.kt
@@ -23,7 +23,7 @@ object UsageGuidePracticeContent {
             PracticeFeedbackExample(
                 id = "practice_signal_red",
                 category = PracticeFeedbackCategory.SIGNAL,
-                title = "빨간불 예시 듣기",
+                title = "빨간불 예시",
                 description = "빨간 보행자 신호가 보일 때의 안내 예시입니다.",
                 speechText = "연습 예시입니다. 빨간불로 보입니다. 실제 이동 전 주변을 확인하세요.",
                 hapticPattern = SignalFeedbackPattern.RED_CONFIRMED
@@ -31,7 +31,7 @@ object UsageGuidePracticeContent {
             PracticeFeedbackExample(
                 id = "practice_signal_green",
                 category = PracticeFeedbackCategory.SIGNAL,
-                title = "초록불 예시 듣기",
+                title = "초록불 예시",
                 description = "초록 보행자 신호가 확인됐을 때의 안내 예시입니다.",
                 speechText = "연습 예시입니다. 초록불로 보입니다. 실제 이동 전 주변을 확인하세요.",
                 hapticPattern = SignalFeedbackPattern.GREEN_CONFIRMED
@@ -39,7 +39,7 @@ object UsageGuidePracticeContent {
             PracticeFeedbackExample(
                 id = "practice_signal_green_caution",
                 category = PracticeFeedbackCategory.SIGNAL,
-                title = "초록불 주의 예시 듣기",
+                title = "주의 필요 예시",
                 description = "초록 신호처럼 보여도 차량이나 주변 상황을 더 조심해야 할 때의 예시입니다.",
                 speechText = "연습 예시입니다. 초록불로 보여도 차량을 주의하세요.",
                 hapticPattern = SignalFeedbackPattern.GREEN_WITH_CAUTION
@@ -47,7 +47,7 @@ object UsageGuidePracticeContent {
             PracticeFeedbackExample(
                 id = "practice_signal_uncertain",
                 category = PracticeFeedbackCategory.SIGNAL,
-                title = "확인 필요 예시 듣기",
+                title = "확인 필요 예시",
                 description = "신호가 불확실하거나 카메라 시야가 부족할 때의 안내 예시입니다.",
                 speechText = "연습 예시입니다. 확인이 필요합니다. 멈추고 주변을 확인하세요.",
                 hapticPattern = SignalFeedbackPattern.WAIT_OR_UNCERTAIN

--- a/app/src/test/java/kr/co/gachon/pproject6/via/feedback/SignalFeedbackPatternsTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/feedback/SignalFeedbackPatternsTest.kt
@@ -1,0 +1,42 @@
+package kr.co.gachon.pproject6.via.feedback
+
+import kr.co.gachon.pproject6.via.ml.AdvisoryState
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+
+class SignalFeedbackPatternsTest {
+    @Test
+    fun runtimeAdvisoryStatesMapToSharedPracticePatterns() {
+        assertArrayEquals(
+            SignalFeedbackPatterns.copyOf(SignalFeedbackPattern.RED_CONFIRMED),
+            SignalFeedbackPatterns.forAdvisoryState(AdvisoryState.RED_CONFIRMED)
+        )
+        assertArrayEquals(
+            SignalFeedbackPatterns.copyOf(SignalFeedbackPattern.GREEN_CONFIRMED),
+            SignalFeedbackPatterns.forAdvisoryState(AdvisoryState.GREEN_CONFIRMED)
+        )
+        assertArrayEquals(
+            SignalFeedbackPatterns.copyOf(SignalFeedbackPattern.GREEN_WITH_CAUTION),
+            SignalFeedbackPatterns.forAdvisoryState(AdvisoryState.GREEN_WITH_CAUTION)
+        )
+        assertArrayEquals(
+            SignalFeedbackPatterns.copyOf(SignalFeedbackPattern.WAIT_OR_UNCERTAIN),
+            SignalFeedbackPatterns.forAdvisoryState(AdvisoryState.UNCERTAIN_VIEW)
+        )
+        assertArrayEquals(
+            SignalFeedbackPatterns.copyOf(SignalFeedbackPattern.WAIT_OR_UNCERTAIN),
+            SignalFeedbackPatterns.forAdvisoryState(AdvisoryState.TRANSITION_WAIT)
+        )
+    }
+
+    @Test
+    fun patternsReturnDefensiveCopies() {
+        val first = SignalFeedbackPatterns.copyOf(SignalFeedbackPattern.RED_CONFIRMED)
+        val second = SignalFeedbackPatterns.copyOf(SignalFeedbackPattern.RED_CONFIRMED)
+
+        assertNotSame(first, second)
+        first[1] = 1
+        assertArrayEquals(longArrayOf(0, 400, 200, 400), second)
+    }
+}

--- a/app/src/test/java/kr/co/gachon/pproject6/via/guide/PracticeFeedbackSafetyBoundaryTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/guide/PracticeFeedbackSafetyBoundaryTest.kt
@@ -1,0 +1,50 @@
+package kr.co.gachon.pproject6.via.guide
+
+import java.io.File
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class PracticeFeedbackSafetyBoundaryTest {
+    @Test
+    fun practicePlayerDoesNotImportLiveGuidanceOrEmergencyActions() {
+        val source = sourceFile("guide/PracticeFeedbackPlayer.kt").readText()
+        val forbiddenTokens =
+            listOf(
+                "AdvisoryAssessment",
+                "onAdvisoryChanged",
+                "Intent",
+                "EmergencyContactActivity",
+                "Location",
+                "Camera"
+            )
+
+        forbiddenTokens.forEach { token ->
+            assertFalse("practice player must not reference $token", source.contains(token))
+        }
+    }
+
+    @Test
+    fun usageGuidePracticeButtonDoesNotWireRealActions() {
+        val source = sourceFile("guide/UsageGuideActivity.kt").readText()
+        val forbiddenTokens =
+            listOf(
+                "onAdvisoryChanged",
+                "startActivity",
+                "sendTextMessage",
+                "requestLocationUpdates",
+                "bindToLifecycle"
+            )
+
+        forbiddenTokens.forEach { token ->
+            assertFalse("usage guide practice UI must not wire $token", source.contains(token))
+        }
+    }
+
+    private fun sourceFile(relativePath: String): File {
+        val fromRoot = File("app/src/main/java/kr/co/gachon/pproject6/via/$relativePath")
+        if (fromRoot.exists()) {
+            return fromRoot
+        }
+        return File("src/main/java/kr/co/gachon/pproject6/via/$relativePath")
+    }
+}

--- a/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
@@ -1,6 +1,7 @@
 package kr.co.gachon.pproject6.via.guide
 
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class UsageGuideContentTest {
@@ -43,6 +44,51 @@ class UsageGuideContentTest {
             "다음 신호 대기 권장"
         ).forEach { label ->
             assertTrue("guide should explain '$label'", content.contains(label))
+        }
+    }
+
+    @Test
+    fun practiceModeIncludesApprovedSignalAndControlExamples() {
+        val titles = UsageGuidePracticeContent.allExamples.map { it.title }
+
+        listOf(
+            "빨간불 예시 듣기",
+            "초록불 예시 듣기",
+            "초록불 주의 예시 듣기",
+            "확인 필요 예시 듣기",
+            "주변 횡단보도 안내",
+            "블루투스 짧게 누르기",
+            "블루투스 길게 누르기"
+        ).forEach { title ->
+            assertTrue("practice examples should contain $title", titles.contains(title))
+        }
+    }
+
+    @Test
+    fun practiceExamplesAreClearlySimulationOnly() {
+        UsageGuidePracticeContent.allExamples.forEach { example ->
+            assertTrue("${example.id} must be simulation only", example.simulationOnly)
+            assertTrue("${example.id} speech should be prefixed as practice", example.speechText.startsWith("연습 예시입니다."))
+        }
+    }
+
+    @Test
+    fun signalPracticeExamplesHaveSharedHapticPatterns() {
+        assertEquals(4, UsageGuidePracticeContent.signalExamples.size)
+        UsageGuidePracticeContent.signalExamples.forEach { example ->
+            assertTrue("${example.id} should have haptic pattern", example.hapticPattern != null)
+        }
+    }
+
+    @Test
+    fun controlPracticeExamplesDoNotClaimRealActionsRun() {
+        val controlText =
+            UsageGuidePracticeContent.controlExamples.joinToString("\n") { example ->
+                "${example.title}\n${example.description}\n${example.speechText}"
+            }
+
+        listOf("실제 위치를 조회하지 않습니다", "실제 안내를 실행하지 않습니다", "비상 연락을 실행하지 않습니다").forEach { phrase ->
+            assertTrue("control practice should state no real action for '$phrase'", controlText.contains(phrase))
         }
     }
 

--- a/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
@@ -1,16 +1,33 @@
 package kr.co.gachon.pproject6.via.guide
 
-import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class UsageGuideContentTest {
     @Test
-    fun guideExplainsRolePermissionsAndMajorFeatures() {
-        val content = fullGuideText()
+    fun guidePrioritizesOkoLikeInteractiveFeedbackPractice() {
+        assertEquals("사용 안내", UsageGuideContent.screenTitle)
+        assertEquals("어떤 피드백을 받나요?", UsageGuideContent.feedbackOverview.title)
 
-        listOf("보조", "카메라", "위치", "SMS", "신호", "횡단보도", "비상 문자", "블루투스").forEach { keyword ->
-            assertTrue("guide should contain $keyword", content.contains(keyword))
+        val signalTitles = UsageGuidePracticeContent.signalExamples.map { it.title }
+        assertEquals(
+            listOf("빨간불 예시", "초록불 예시", "주의 필요 예시", "확인 필요 예시"),
+            signalTitles
+        )
+    }
+
+    @Test
+    fun guideKeepsOnlyCompactUserNecessarySections() {
+        val titles = UsageGuideContent.sections.map { it.title }
+
+        listOf("어떻게 작동하나요?", "휴대폰은 어떻게 들까요?", "피드백이 없으면?", "빠른 조작", "안전 안내").forEach { title ->
+            assertTrue("guide should contain $title", titles.contains(title))
+        }
+
+        listOf("VIA가 하는 일", "중요 안전 안내", "권한을 쓰는 이유", "주요 기능", "블루투스 버튼", "상태 문구의 의미", "초기 최적화").forEach { oldTitle ->
+            assertFalse("guide should remove old long category $oldTitle", titles.contains(oldTitle))
         }
     }
 
@@ -18,8 +35,8 @@ class UsageGuideContentTest {
     fun guideIncludesClearSafetyDisclaimer() {
         val content = fullGuideText()
 
-        assertTrue(content.contains("최종 판단을 대신하지 않습니다"))
-        assertTrue(content.contains("주변 상황"))
+        assertTrue(content.contains("보행 판단을 대신하지 않습니다"))
+        assertTrue(content.contains("주변"))
     }
 
     @Test
@@ -29,38 +46,6 @@ class UsageGuideContentTest {
 
         forbiddenPhrases.forEach { phrase ->
             assertTrue("guide should not contain '$phrase'", !content.contains(phrase))
-        }
-    }
-
-    @Test
-    fun guideExplainsFinalAdvisoryStateLabels() {
-        val content = fullGuideText()
-
-        listOf(
-            "보행자 신호 초록으로 보임",
-            "보행자 신호 빨간색으로 보임",
-            "초록으로 보이나 주의 필요",
-            "신호 확인 불확실",
-            "다음 신호 대기 권장"
-        ).forEach { label ->
-            assertTrue("guide should explain '$label'", content.contains(label))
-        }
-    }
-
-    @Test
-    fun practiceModeIncludesApprovedSignalAndControlExamples() {
-        val titles = UsageGuidePracticeContent.allExamples.map { it.title }
-
-        listOf(
-            "빨간불 예시 듣기",
-            "초록불 예시 듣기",
-            "초록불 주의 예시 듣기",
-            "확인 필요 예시 듣기",
-            "주변 횡단보도 안내",
-            "블루투스 짧게 누르기",
-            "블루투스 길게 누르기"
-        ).forEach { title ->
-            assertTrue("practice examples should contain $title", titles.contains(title))
         }
     }
 
@@ -93,8 +78,14 @@ class UsageGuideContentTest {
     }
 
     private fun fullGuideText(): String {
-        return UsageGuideContent.sections.joinToString("\n") { section ->
-            "${section.title}\n${section.body}"
+        return buildString {
+            appendLine(UsageGuideContent.intro)
+            appendLine(UsageGuideContent.feedbackOverview.title)
+            appendLine(UsageGuideContent.feedbackOverview.body)
+            UsageGuideContent.sections.forEach { section ->
+                appendLine(section.title)
+                appendLine(section.body)
+            }
         }
     }
 }

--- a/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
@@ -66,15 +66,17 @@ class UsageGuideContentTest {
     }
 
     @Test
-    fun controlPracticeExamplesDoNotClaimRealActionsRun() {
+    fun controlPracticeExamplesExplainRealUserFacingBehavior() {
         val controlText =
             UsageGuidePracticeContent.controlExamples.joinToString("\n") { example ->
                 "${example.title}\n${example.description}\n${example.speechText}"
             }
 
-        listOf("실제 위치를 조회하지 않습니다", "실제 안내를 실행하지 않습니다", "비상 연락을 실행하지 않습니다").forEach { phrase ->
-            assertTrue("control practice should state no real action for '$phrase'", controlText.contains(phrase))
+        listOf("가까운 횡단보도의 거리와 방향", "짧게 누르면 주변 횡단보도 안내", "길게 누르면 비상 문자 5초 유예 화면").forEach { phrase ->
+            assertTrue("control practice should explain actual behavior for '$phrase'", controlText.contains(phrase))
         }
+        assertTrue("control practice should use user-facing Bluetooth wording", controlText.contains("블루투스 버튼"))
+        assertTrue("control practice should not mention implementation key wording", !controlText.contains("Space 키"))
     }
 
     private fun fullGuideText(): String {

--- a/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
+++ b/app/src/test/java/kr/co/gachon/pproject6/via/guide/UsageGuideContentTest.kt
@@ -72,7 +72,7 @@ class UsageGuideContentTest {
                 "${example.title}\n${example.description}\n${example.speechText}"
             }
 
-        listOf("가까운 횡단보도의 거리와 방향", "짧게 누르면 주변 횡단보도 안내", "길게 누르면 비상 문자 5초 유예 화면").forEach { phrase ->
+        listOf("전방 약 18미터", "주변 횡단보도 안내를 실행합니다", "5초 안에 취소하지 않으면 등록된 비상 연락처로 문자를 보냅니다").forEach { phrase ->
             assertTrue("control practice should explain actual behavior for '$phrase'", controlText.contains(phrase))
         }
         assertTrue("control practice should use user-facing Bluetooth wording", controlText.contains("블루투스 버튼"))


### PR DESCRIPTION
## 요약
- 기존 `?` 사용 안내를 OKO 참고 이미지처럼 연습 우선 흐름으로 재구성했습니다.
- 긴 정적 카테고리 목록을 제거하고, 상단에 `어떤 피드백을 받나요?` 체험 카드를 배치했습니다.
- 빨간불/초록불/주의 필요/확인 필요 예시를 시각적으로 구분하고, 각 예시를 바로 재생할 수 있게 했습니다.
- 휴대폰 들기, 피드백이 없을 때 대처, 빠른 조작, 안전 안내만 짧은 카드로 남겼습니다.
- 모든 연습은 실제 카메라 분석, 위치 조회, 비상 문자, 실시간 안내를 실행하지 않습니다.

## 구현 메모
- 런타임과 연습 모드가 같은 진동 패턴을 쓰도록 `SignalFeedbackPatterns`를 유지합니다.
- `PracticeFeedbackPlayer`는 `play`, `stop`, `release`만 노출하고 usage guide 안에서만 사용합니다.
- 화면 이탈 시 연습 TTS/진동을 중지하고 종료 시 리소스를 해제합니다.

## 검증
- `./gradlew testDebugUnitTest`
- `./gradlew lintDebug`
- `./gradlew assembleDebug`
- 최종 묶음 검증: `./gradlew testDebugUnitTest lintDebug assembleDebug`
- 코드 리뷰: APPROVE / CLEAR

Closes #71
