### PR TITLE
release: sync develop documentation to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/작업용-이슈.md
+++ b/.github/ISSUE_TEMPLATE/작업용-이슈.md
@@ -1,6 +1,6 @@
 ---
-name: 작업용 이슈
-about: 기능, 버그, 문서, 운영 작업을 기록합니다.
+name: 프로젝트 이슈
+about: 기능, 버그, 문서, 운영 작업을 정리합니다.
 title: '[Type] '
 labels: ''
 assignees: ''

--- a/README.md
+++ b/README.md
@@ -210,4 +210,6 @@ Then validate on a physical device outdoors or with representative replay footag
 
 ## License
 
-No repository-level open-source license file is currently present in this checkout. Treat the code, bundled models, map data, and documentation as all-rights-reserved/internal project material until the project owner adds an explicit license and third-party attribution policy.
+This project is released under the MIT License. See [LICENSE](LICENSE) for the full license text.
+
+Third-party libraries, model artifacts, and map/open-data sources may have their own licenses or attribution requirements; review their upstream terms before redistribution.


### PR DESCRIPTION
## 작업 내용
- `develop`에 병합된 README License/메타데이터 문구 정리를 `main`에 반영합니다.

## 변경 범위
- [ ] 앱 런타임 코드
- [ ] 테스트 코드
- [x] 문서/템플릿/라이선스
- [ ] 빌드/CI 설정

## 확인 방법
- [x] PR diff가 README 및 issue template 문구 정리만 포함하는지 확인
- [x] `develop -> main` 방향 확인

## 안전/회귀 확인
- [x] 앱 런타임 코드는 변경하지 않았습니다.
- [x] 불필요한 로그, 임시 파일, 대용량 산출물을 포함하지 않았습니다.